### PR TITLE
[2022.07.23] Feat/SongDetailViewUI >> #21 TunePickerView와 LevelPickerView에 임시 배열 추가

### DIFF
--- a/Semo.xcodeproj/project.pbxproj
+++ b/Semo.xcodeproj/project.pbxproj
@@ -319,7 +319,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B2108F1628845A67002CED9D /* TunePickerView.swift in Sources */,
-				EEAD176828828B46009388DD /* ContentView.swift in Sources */,
 				EEC3B54E2883A79C0036BE34 /* MainView.swift in Sources */,
 				B2108F1A28845AE9002CED9D /* SongInfoView.swift in Sources */,
 				EEAD17742882AA2F009388DD /* SongListView.swift in Sources */,

--- a/Semo/Views/SongDetail/LevelPickerView.swift
+++ b/Semo/Views/SongDetail/LevelPickerView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct LevelPickerView: View {
-    @State var levels = ["하", "중", "상"]
+    var levels = ["하", "중", "상"]
     @State var level = "중"
     
     var body: some View {

--- a/Semo/Views/SongDetail/LevelPickerView.swift
+++ b/Semo/Views/SongDetail/LevelPickerView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct LevelPickerView: View {
+    @State var levels = ["하", "중", "상"]
+    @State var level = "중"
+    
     var body: some View {
         VStack {
             HStack {

--- a/Semo/Views/SongDetail/TunePickerView.swift
+++ b/Semo/Views/SongDetail/TunePickerView.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct TunePickerView: View {
-    @State var gender = 1
+    @State var genders = ["여성", "혼성", "남성"]
+    @State var tunes = ["-6", "-5", "-4", "-3", "-2", "-1",
+                         "0", "1", "2", "3", "4", "5", "6"]
+    @State var gender = "혼성"
+    @State var tune = "0"
     
     var body: some View {
         VStack {
@@ -17,11 +21,11 @@ struct TunePickerView: View {
                 ContentsTitleView(titleName: "키")
                 Spacer()
             }
-            Picker("pick gender", selection: $gender, content: {
-                Text("여성").tag(0)
-                Text("혼성").tag(1)
-                Text("남성").tag(2)
-            })
+            Picker("pick gender", selection: $gender) {
+                ForEach(genders, id: \.self) {
+                    Text($0)
+                }
+            }
             .pickerStyle(SegmentedPickerStyle())
             .padding(EdgeInsets(top: 24, leading: 24, bottom: 0, trailing: 24))
             // MARK: - 키 picker

--- a/Semo/Views/SongDetail/TunePickerView.swift
+++ b/Semo/Views/SongDetail/TunePickerView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct TunePickerView: View {
-    @State var genders = ["여성", "혼성", "남성"]
-    @State var tunes = ["-6", "-5", "-4", "-3", "-2", "-1",
+    var genders = ["여성", "혼성", "남성"]
+    var tunes = ["-6", "-5", "-4", "-3", "-2", "-1",
                          "0", "1", "2", "3", "4", "5", "6"]
     @State var gender = "혼성"
     @State var tune = "0"


### PR DESCRIPTION
## 작업사항
- TunePickerView에 genders, tunes 임시 배열 추가
- LevelPickerView에 levels 임시 배열 추가

## 이슈 번호
#21 


## 특이사항 (optional)
배열을 사용하기 위한 임시 데이터입니다! 추후에 데이터 모델과 연결될 예정입니다.
