### PR TITLE
[2022.08.10] feat/addSongFlowComplete>> AddSingingListTagView UI 구현 및 네비게이션 링크로 연결

### DIFF
--- a/Semo.xcodeproj/project.pbxproj
+++ b/Semo.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		B2108F1A28845AE9002CED9D /* SongInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2108F1928845AE9002CED9D /* SongInfoView.swift */; };
 		B242DEA92886C3D10052031C /* AddMoreInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B242DEA82886C3D10052031C /* AddMoreInfoView.swift */; };
 		B262DD0D2883F86F00E1B527 /* SongDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B262DD0C2883F86F00E1B527 /* SongDetailView.swift */; };
+		B2983F7028A2AF950064C79A /* AddSingingListTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2983F6F28A2AF950064C79A /* AddSingingListTagView.swift */; };
 		B2A36E322885A6560031D282 /* ContentsTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A36E312885A6560031D282 /* ContentsTitleView.swift */; };
 		C5200BDEAC2C4BE3A51404E6 /* Pods_Semo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 533DF943DAA76770EFE704E6 /* Pods_Semo.framework */; };
 		EEAD176628828B46009388DD /* SemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAD176528828B46009388DD /* SemoApp.swift */; };
@@ -78,6 +79,7 @@
 		B2108F1928845AE9002CED9D /* SongInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongInfoView.swift; sourceTree = "<group>"; };
 		B242DEA82886C3D10052031C /* AddMoreInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMoreInfoView.swift; sourceTree = "<group>"; };
 		B262DD0C2883F86F00E1B527 /* SongDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongDetailView.swift; sourceTree = "<group>"; };
+		B2983F6F28A2AF950064C79A /* AddSingingListTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSingingListTagView.swift; sourceTree = "<group>"; };
 		B2A36E312885A6560031D282 /* ContentsTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentsTitleView.swift; sourceTree = "<group>"; };
 		EEAD176228828B46009388DD /* Semo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Semo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EEAD176528828B46009388DD /* SemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemoApp.swift; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 			children = (
 				209E12E02883F186006FB3A8 /* AddSongView.swift */,
 				B242DEA82886C3D10052031C /* AddMoreInfoView.swift */,
+				B2983F6F28A2AF950064C79A /* AddSingingListTagView.swift */,
 			);
 			path = AddSong;
 			sourceTree = "<group>";
@@ -419,6 +422,7 @@
 			files = (
 				B2108F1628845A67002CED9D /* TunePickerView.swift in Sources */,
 				EEC3B54E2883A79C0036BE34 /* MainView.swift in Sources */,
+				B2983F7028A2AF950064C79A /* AddSingingListTagView.swift in Sources */,
 				B2108F1A28845AE9002CED9D /* SongInfoView.swift in Sources */,
 				EEAD17742882AA2F009388DD /* SongListView.swift in Sources */,
 				B2108F1428845A5A002CED9D /* LevelPickerView.swift in Sources */,

--- a/Semo.xcodeproj/project.pbxproj
+++ b/Semo.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		B242DEA92886C3D10052031C /* AddMoreInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B242DEA82886C3D10052031C /* AddMoreInfoView.swift */; };
 		B262DD0D2883F86F00E1B527 /* SongDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B262DD0C2883F86F00E1B527 /* SongDetailView.swift */; };
 		B2983F7028A2AF950064C79A /* AddSingingListTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2983F6F28A2AF950064C79A /* AddSingingListTagView.swift */; };
+		B2983F7228A2C6E50064C79A /* NavigationUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2983F7128A2C6E50064C79A /* NavigationUtil.swift */; };
 		B2A36E322885A6560031D282 /* ContentsTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A36E312885A6560031D282 /* ContentsTitleView.swift */; };
 		C5200BDEAC2C4BE3A51404E6 /* Pods_Semo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 533DF943DAA76770EFE704E6 /* Pods_Semo.framework */; };
 		EEAD176628828B46009388DD /* SemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAD176528828B46009388DD /* SemoApp.swift */; };
@@ -80,6 +81,7 @@
 		B242DEA82886C3D10052031C /* AddMoreInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMoreInfoView.swift; sourceTree = "<group>"; };
 		B262DD0C2883F86F00E1B527 /* SongDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongDetailView.swift; sourceTree = "<group>"; };
 		B2983F6F28A2AF950064C79A /* AddSingingListTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSingingListTagView.swift; sourceTree = "<group>"; };
+		B2983F7128A2C6E50064C79A /* NavigationUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationUtil.swift; sourceTree = "<group>"; };
 		B2A36E312885A6560031D282 /* ContentsTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentsTitleView.swift; sourceTree = "<group>"; };
 		EEAD176228828B46009388DD /* Semo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Semo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EEAD176528828B46009388DD /* SemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemoApp.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				209E12E22883F1CA006FB3A8 /* TextFieldView.swift */,
 				209E12E62883F3F3006FB3A8 /* ConfirmButtonView.swift */,
 				3928C59F28A18962006D3D19 /* FinalConfirmButtonView.swift */,
+				B2983F7128A2C6E50064C79A /* NavigationUtil.swift */,
 			);
 			path = Others;
 			sourceTree = "<group>";
@@ -457,6 +460,7 @@
 				3928C5A028A18962006D3D19 /* FinalConfirmButtonView.swift in Sources */,
 				39FE869B28828DBD00D0F24F /* TestModel.swift in Sources */,
 				3916A13B2883AD0500C21828 /* SingingList+CoreDataClass.swift in Sources */,
+				B2983F7228A2C6E50064C79A /* NavigationUtil.swift in Sources */,
 				3928C59A28A1800F006D3D19 /* CheckboxToggleStyle.swift in Sources */,
 				EEC3B553288408390036BE34 /* SingingListDetailView.swift in Sources */,
 			);

--- a/Semo/Views/AddSong/AddMoreInfoView.swift
+++ b/Semo/Views/AddSong/AddMoreInfoView.swift
@@ -37,11 +37,11 @@ struct AddMoreInfoView: View {
                 Spacer()
                 
                 // TODO: - 데이터 저장하고 다음 단계로 넘어가기
-                NavigationLink(destination: TestDetailView()) {
+                NavigationLink(destination: AddSingingListTagView()) {
                     ConfirmButtonView(buttonName: "확인")
                 }
                 .navigationTitle("")
-                NavigationLink(destination: TestDetailView()) {
+                NavigationLink(destination: AddSingingListTagView()) {
                     Text("건너뛰기")
                         .foregroundColor(.grayScale1)
                         .font(.system(size: 16, weight: .semibold))

--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -22,11 +22,12 @@ struct AddSingingListTagView: View {
             // MARK: - main으로 연결되는 확인 버튼
             VStack {
                 Spacer()
-                NavigationLink(destination: TestDetailView()) {
+                Button(action: {
+                    NavigationUtil.popToRootView()
+                }, label: {
                     ConfirmButtonView(buttonName: "확인")
                         .padding(.bottom, 60)
-                }
-                .navigationTitle("")
+                })
             }
             .ignoresSafeArea(.keyboard)
             // MARK: - 타이틀 및 싱잉리스트 뷰

--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -28,6 +28,7 @@ struct AddSingingListTagView: View {
                 }
                 .navigationTitle("")
             }
+            .ignoresSafeArea(.keyboard)
             // MARK: - 타이틀 및 싱잉리스트 뷰
             VStack(alignment: .center) {
                 Text("이 노래가 들어갈 싱잉리스트를 \n선택해주세요.")

--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -72,7 +72,6 @@ struct AddSingingListTagView: View {
                     }, label: {
                         FinalConfirmButtonView(buttonName: "리스트 추가하기")
                     })
-                    .padding(.bottom, 1)
                 }
             }
         }

--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -1,0 +1,86 @@
+//
+//  AddSingingListTagView.swift
+//  Semo
+//
+//  Created by 조은비 on 2022/08/09.
+//
+
+import SwiftUI
+
+struct AddSingingListTagView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \SingingList.timestamp, ascending: true)], animation: .default) private var singingList: FetchedResults<SingingList>
+    @State var newSingingListTitle: String = ""
+    @State var singingListToggle: [UUID: Bool] = [:]
+    @FocusState private var textFieldIsFocused: Bool
+    
+    var body: some View {
+        ZStack {
+            Color.backgroundBlack.ignoresSafeArea()
+            LinearGradient(gradient: Gradient(colors: [Color.grayScale6, Color.backgroundBlack]), startPoint: .top, endPoint: UnitPoint(x: 0.5, y: 0.3))
+            .edgesIgnoringSafeArea(.all)
+            // MARK: - main으로 연결되는 확인 버튼
+            VStack {
+                Spacer()
+                NavigationLink(destination: TestDetailView()) {
+                    ConfirmButtonView(buttonName: "확인")
+                        .padding(.bottom, 60)
+                }
+                .navigationTitle("")
+            }
+            // MARK: - 타이틀 및 싱잉리스트 뷰
+            VStack(alignment: .center) {
+                Text("이 노래가 들어갈 싱잉리스트를 \n선택해주세요.")
+                    .lineSpacing(10)
+                    .frame(width: UIScreen.main.bounds.width, alignment: .leading)
+                    .foregroundColor(.white)
+                    .font(.system(size: 24, weight: .semibold))
+                    .padding(EdgeInsets(top: 14, leading: 20, bottom: 0, trailing: 0))
+                TextFieldView(text: $newSingingListTitle, placeholder: "새로운 리스트를 바로 추가해보세요.")
+                    .disableAutocorrection(true)
+                    .padding(.horizontal, 20)
+                    .focused($textFieldIsFocused)
+                HStack {
+                    ContentsTitleView(titleName: "싱잉리스트")
+                    Spacer()
+                }
+                ScrollView{
+                    SingingListToggleView(toggleDictionary: $singingListToggle, newSingingListTitle: $newSingingListTitle)
+                }
+                .padding(.bottom, 120)
+            }
+            .ignoresSafeArea(.keyboard)
+            // MARK: - 키보드가 올라왔을 때 보이는 추가 버튼
+            VStack {
+                Spacer()
+                if textFieldIsFocused == true {
+                    // TODO: - textField가 focus되지 않았을 때 버튼 회색으로 변경
+                    Button(action: {
+                        // 새로운 SingingList coreData에 추가
+                        let newSingingList: SingingList = SingingList(context: viewContext)
+                        newSingingList.timestamp = Date()
+                        newSingingList.id = UUID()
+                        newSingingList.title = newSingingListTitle
+                        newSingingList.count = 0
+                        do {
+                            try viewContext.save()
+                        } catch {
+                            print(error.localizedDescription)
+                        }
+                        newSingingListTitle = ""
+                        textFieldIsFocused = false
+                    }, label: {
+                        FinalConfirmButtonView(buttonName: "리스트 추가하기")
+                    })
+                    .padding(.bottom, 1)
+                }
+            }
+        }
+    }
+}
+
+struct AddSingingListTagView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddSingingListTagView()
+    }
+}

--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -12,7 +12,7 @@ struct AddSingingListTagView: View {
     @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \SingingList.timestamp, ascending: true)], animation: .default) private var singingList: FetchedResults<SingingList>
     @State var newSingingListTitle: String = ""
     @State var singingListToggle: [UUID: Bool] = [:]
-    @FocusState private var textFieldIsFocused: Bool
+    @FocusState private var isTextFieldFocused: Bool
     
     var body: some View {
         ZStack {
@@ -41,7 +41,7 @@ struct AddSingingListTagView: View {
                 TextFieldView(text: $newSingingListTitle, placeholder: "새로운 리스트를 바로 추가해보세요.")
                     .disableAutocorrection(true)
                     .padding(.horizontal, 20)
-                    .focused($textFieldIsFocused)
+                    .focused($isTextFieldFocused)
                 HStack {
                     ContentsTitleView(titleName: "싱잉리스트")
                     Spacer()
@@ -55,7 +55,7 @@ struct AddSingingListTagView: View {
             // MARK: - 키보드가 올라왔을 때 보이는 추가 버튼
             VStack {
                 Spacer()
-                if textFieldIsFocused == true {
+                if isTextFieldFocused == true {
                     // TODO: - textField가 focus되지 않았을 때 버튼 회색으로 변경
                     Button(action: {
                         // 새로운 SingingList coreData에 추가
@@ -70,7 +70,7 @@ struct AddSingingListTagView: View {
                             print(error.localizedDescription)
                         }
                         newSingingListTitle = ""
-                        textFieldIsFocused = false
+                        isTextFieldFocused = false
                     }, label: {
                         FinalConfirmButtonView(buttonName: "리스트 추가하기")
                     })

--- a/Semo/Views/AddSong/AddSongView.swift
+++ b/Semo/Views/AddSong/AddSongView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AddSongView: View {
     @State var songTitle: String = ""
     @State var songSinger: String = ""
+    
     var body: some View {
         ZStack {
             Color.backgroundBlack.ignoresSafeArea()
@@ -41,14 +42,12 @@ struct AddSongView: View {
                 
                 TextFieldView(text: $songSinger, placeholder: "가수의 이름이 무엇인가요?")
                     .frame(width: 350, height: 20, alignment: .leading)
-                
-                Button(action: {
-                    print(songTitle)
-                    print(songSinger)
-                }, label: {
+                Spacer()
+                NavigationLink(destination: AddMoreInfoView()) {
                     ConfirmButtonView(buttonName: "확인")
-                        .padding(.top, 88)
-                })
+                        .padding(.bottom, 60)
+                }
+                .navigationTitle("")
                 
                 Spacer()
                 

--- a/Semo/Views/Others/NavigationUtil.swift
+++ b/Semo/Views/Others/NavigationUtil.swift
@@ -1,0 +1,31 @@
+//
+//  NavigationUtil.swift
+//  Semo
+//
+//  Created by 조은비 on 2022/08/10.
+//
+
+import SwiftUI
+
+struct NavigationUtil {
+    static func popToRootView() {
+        findNavigationController(viewController: UIApplication.shared.windows.filter { $0.isKeyWindow }.first?.rootViewController)?
+            .popToRootViewController(animated: true)
+    }
+    
+    static func findNavigationController(viewController: UIViewController?) -> UINavigationController? {
+        guard let viewController = viewController else {
+            return nil
+        }
+        
+        if let navigationController = viewController as? UINavigationController {
+            return navigationController
+        }
+        
+        for childViewController in viewController.children {
+            return findNavigationController(viewController: childViewController)
+        }
+        
+        return nil
+    }
+}


### PR DESCRIPTION
## 시뮬레이션
![Simulator Screen Recording - iPhone 13 - 2022-08-10 at 00 24 05](https://user-images.githubusercontent.com/98628614/183690515-1bbb9893-4f73-4367-aef8-52e78dc49b65.gif)

## 작업사항
- AddSingingListTagView UI 구현
- addSong 플로우 네비게이션 링크로 연결

## 이슈 번호
#37 

## TODO
- [x] 마지막 단계에서 확인 버튼누르면 메인 페이지로 돌아가기
- [ ] AddSongView 좌우 마진값 수정
- [ ] AddSingingListTagView 텍스트필드 포커스되었을 때만 버튼색 보라색이 되도록 수정
- [ ] SingingList 스크롤 뷰 백그라운드 컬러 수정
- [ ] 데이터 연결
