### PR TITLE
[2022.08.14] hotfix/fixAddSongViews >> 디테일 UI 및 버튼 스타일 수정

### DIFF
--- a/Semo/Views/AddSong/AddMoreInfoView.swift
+++ b/Semo/Views/AddSong/AddMoreInfoView.swift
@@ -41,12 +41,14 @@ struct AddMoreInfoView: View {
                     ConfirmButtonView(buttonName: "확인")
                 }
                 .navigationTitle("")
-                NavigationLink(destination: AddSingingListTagView()) {
+                Button(action: {
+                    NavigationUtil.popToRootView()
+                }, label: {
                     Text("건너뛰기")
                         .foregroundColor(.grayScale1)
                         .font(.system(size: 16, weight: .semibold))
                         .padding(EdgeInsets(top: 28, leading: 0, bottom: 60, trailing: 0))
-                }
+                })
             }
         }
         .navigationBarTitle("", displayMode: .inline)

--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -72,11 +72,19 @@ struct AddSingingListTagView: View {
                         newSingingListTitle = ""
                         isTextFieldFocused = false
                     }, label: {
-                        FinalConfirmButtonView(buttonName: "리스트 추가하기")
+                        FinalConfirmButtonView(buttonName: "리스트 추가하기",
+                                               buttonColor: newSingingListTitle.isEmpty ? .grayScale5 : Color.mainPurpleColor,
+                                               textColor: newSingingListTitle.isEmpty ? .grayScale3 : .white)
                     })
+                    .disabled(newSingingListTitle == "")
                 }
             }
         }
+        .onAppear(perform: {
+            for i in singingList {
+                singingListToggle[i.id!] = false
+            }
+        })
     }
 }
 

--- a/Semo/Views/Others/FinalConfirmButtonView.swift
+++ b/Semo/Views/Others/FinalConfirmButtonView.swift
@@ -9,21 +9,25 @@ import SwiftUI
 
 struct FinalConfirmButtonView: View {
     var buttonName: String
-    init(buttonName: String) {
+    var buttonColor: Color
+    var textColor: Color
+    init(buttonName: String, buttonColor: Color, textColor: Color) {
         self.buttonName = buttonName
+        self.buttonColor = buttonColor
+        self.textColor = textColor
     }
     var body: some View {
         Text(buttonName)
             .font(.system(size: 16, weight: .semibold))
-            .foregroundColor(.white)
+            .foregroundColor(textColor)
             .padding()
             .frame(width: UIScreen.main.bounds.size.width, height: 48)
-            .background(Color.mainPurpleColor)
+            .background(buttonColor)
     }
 }
 
 struct FinalConfirmButtonView_Previews: PreviewProvider {
     static var previews: some View {
-        FinalConfirmButtonView(buttonName: "확인")
+        FinalConfirmButtonView(buttonName: "확인", buttonColor: Color.mainPurpleColor, textColor: .white)
     }
 }

--- a/Semo/Views/SingingList/SingingListSheet/CheckboxToggleStyle.swift
+++ b/Semo/Views/SingingList/SingingListSheet/CheckboxToggleStyle.swift
@@ -39,7 +39,7 @@ struct CheckboxToggleStyle: ToggleStyle {
         }
         .padding(EdgeInsets(top: 14, leading: 20, bottom: 14, trailing: 40))
         .frame(height: 50)
-        .background(configuration.isOn ? Color.grayScale3 : Color.grayScale7)
+        .background(configuration.isOn ? Color.grayScale3 : Color.black.opacity(0))
         .contentShape(Rectangle())
         .onTapGesture {
             print("tab")

--- a/Semo/Views/SingingList/SingingListSheet/SingingListSheetView.swift
+++ b/Semo/Views/SingingList/SingingListSheet/SingingListSheetView.swift
@@ -59,8 +59,11 @@ struct SingingListSheetView: View {
                     }
                     newSingingListTitle = ""
                 }, label: {
-                    FinalConfirmButtonView(buttonName: newSingingListTitle.isEmpty ? "확인" : "리스트 추가하기")
+                    FinalConfirmButtonView(buttonName: newSingingListTitle.isEmpty ? "확인" : "리스트 추가하기",
+                                           buttonColor: Color.mainPurpleColor,
+                                           textColor: newSingingListTitle.isEmpty ? .grayScale3 : .white)
                 })
+                .disabled(newSingingListTitle == "")
             }
             .padding(EdgeInsets(top: 40, leading: 0, bottom: 1, trailing: 0))
         }

--- a/Semo/Views/SingingListDetail/SingingListModalView.swift
+++ b/Semo/Views/SingingListDetail/SingingListModalView.swift
@@ -43,8 +43,11 @@ struct SingingListModalView: View {
                     singingListTitle = ""
                     self.presentationMode.wrappedValue.dismiss()
                 } label: {
-                    FinalConfirmButtonView(buttonName: "리스트 추가하기")
+                    FinalConfirmButtonView(buttonName: "리스트 추가하기",
+                                           buttonColor: singingListTitle.isEmpty ? .grayScale5 : Color.mainPurpleColor,
+                                           textColor: singingListTitle.isEmpty ? .grayScale3 : .white)
                 }
+                .disabled(singingListTitle == "")
                 Spacer()
             }
             .padding(.top, 36)


### PR DESCRIPTION

![Simulator Screen Recording - iPhone 13 - 2022-08-14 at 17 10 17](https://user-images.githubusercontent.com/98628614/184529116-9952af41-bf52-4282-b674-493241397316.gif)

## 작업사항
- AddSingingListTagView, SingingListSheetView, SingingListModalView에서 textfield가 비었을 때, finalConfirmButton disabled 스타일(buttonColor: grayScale5, textColor: grayScale3)로 적용
- CheckboxToggleStyle 체크 안되었을 때 배경색 투명하게 변경
- AddSingingListTagView 토글 한꺼번에 체크되는 버그 수정
- AddMoreInfoView에서 건너뛰기 버튼 경로 수정

## 이슈 번호
#50

## 특이사항 (optional)
이슈에 있는 태스크 수정하면서 연결되어 있는 뷰인 FinalConfirmButtonView, SingingListSheetView, SingingListModalView도 변경되었습니다.