### PR TITLE
[2022.09.14] feat/duplicateCheck >> CoreData에 데이터 저장시 중복검사, Song의 SingingLIst태그 삭제 로직

### DIFF
--- a/Semo.xcodeproj/project.pbxproj
+++ b/Semo.xcodeproj/project.pbxproj
@@ -430,7 +430,6 @@
 				EEAD17842882E4CD009388DD /* SingingListCellView.swift in Sources */,
 				3992665628A1BD4D001849E6 /* TestDetailView.swift in Sources */,
 				EEAD177D2882BE63009388DD /* ColorExtension.swift in Sources */,
-				B2108F1828845A74002CED9D /* SingingListTagView.swift in Sources */,
 				B262DD0D2883F86F00E1B527 /* SongDetailView.swift in Sources */,
 				EE6E6DE228A2738B004F030C /* SingingListModalView.swift in Sources */,
 				B242DEA92886C3D10052031C /* AddMoreInfoView.swift in Sources */,

--- a/Semo/Managers/CoreDataManager.swift
+++ b/Semo/Managers/CoreDataManager.swift
@@ -14,27 +14,47 @@ class CoreDataManager {
     
     private init() {}
     
+    // MARK: - 새로운 노래 저장
     func saveNewSong(songTitle: String, songSinger: String) {
-        let newSong: Song = Song(context: self.viewContext)
-        newSong.timestamp = Date()
-        newSong.id = UUID()
-        newSong.title = songTitle
-        newSong.singer = songSinger
         do {
-            try viewContext.save()
+            let fetchRequest = NSFetchRequest<Song>(entityName: "Song")
+            fetchRequest.predicate = NSPredicate(format: "title == %@ && singer == %@", songTitle, songSinger)
+            let fetchedResults = try viewContext.fetch(fetchRequest)
+            // 중복 검사
+            guard (fetchedResults.first?.title) != nil  else {
+                let newSong: Song = Song(context: self.viewContext)
+                newSong.timestamp = Date()
+                newSong.id = UUID()
+                newSong.title = songTitle
+                newSong.singer = songSinger
+                try viewContext.save()
+                print("title : \(songTitle), singer : \(songSinger) 저장 완료")
+                return
+            }
+            print("[중복 노래] title : \(songTitle), singer : \(songSinger) 저장 불가")
         } catch {
             print(error.localizedDescription)
         }
     }
     
+    // MARK: - 새로운 싱잉리스트 생성
     func saveNewSingingList(singingListTitle: String) {
-        let newSingingList: SingingList = SingingList(context: self.viewContext)
-        newSingingList.timestamp = Date()
-        newSingingList.id = UUID()
-        newSingingList.title = singingListTitle
-        newSingingList.count = 0
         do {
-            try viewContext.save()
+            let fetchRequest = NSFetchRequest<SingingList>(entityName: "SingingList")
+            fetchRequest.predicate = NSPredicate(format: "title == %@", singingListTitle)
+            let fetchedResults = try viewContext.fetch(fetchRequest)
+            // 중복 검사
+            guard (fetchedResults.first?.title) != nil else {
+                let newSingingList: SingingList = SingingList(context: self.viewContext)
+                newSingingList.timestamp = Date()
+                newSingingList.id = UUID()
+                newSingingList.title = singingListTitle
+                newSingingList.count = 0
+                try viewContext.save()
+                print("title : \(singingListTitle) 싱잉리스트 생성 완료")
+                return
+            }
+            print("[중복 싱잉리스트] title : \(singingListTitle) 싱잉리스트 생성 불가")
         } catch {
             print(error.localizedDescription)
         }

--- a/Semo/Views/SingingList/SingingListSheet/SingingListSheetView.swift
+++ b/Semo/Views/SingingList/SingingListSheet/SingingListSheetView.swift
@@ -15,6 +15,7 @@ struct SingingListSheetView: View {
     @Binding var refresh: Bool
     @Binding var isPresent: Bool
     var song: Song
+    
     var body: some View {
         ZStack {
             Color.grayScale7.ignoresSafeArea()
@@ -26,14 +27,18 @@ struct SingingListSheetView: View {
                     SingingListToggleView(toggleDictionary: $singingListToggle, newSingingListTitle: $newSingingListTitle)
                 }
                 Button(action: {
+                    // TextFieldView가 비어있을때
                     if newSingingListTitle.isEmpty {
                         var checkedSingingList: [UUID] = []
                         for i in singingList {
                             if singingListToggle[i.id!] == true {
+                                // 새로운 노래가 추가 되니 count 1 증가
                                 i.count += 1
+                                // 싱잉리스트에 해당 노래 추가
                                 i.addToSingingListToSong(song)
                             }
                         }
+                        // 싱잉리스트에 변경 사항 저장
                         do {
                             try viewContext.save()
                         } catch {
@@ -48,7 +53,7 @@ struct SingingListSheetView: View {
                         newSingingList.id = UUID()
                         newSingingList.title = newSingingListTitle
                         newSingingList.count = 0
-                        
+                        // 새로 추가한 싱잉리스트는 자동 선택하게 토글 활성화
                         singingListToggle.updateValue(true, forKey: newSingingList.id!)
                         do {
                             try viewContext.save()
@@ -57,6 +62,7 @@ struct SingingListSheetView: View {
                             print(error.localizedDescription)
                         }
                     }
+                    // 새로운 싱잉리스트 코어데이터에 추가 후 TextFieldView 초기화
                     newSingingListTitle = ""
                 }, label: {
                     FinalConfirmButtonView(buttonName: newSingingListTitle.isEmpty ? "확인" : "리스트 추가하기",
@@ -67,6 +73,7 @@ struct SingingListSheetView: View {
             }
             .padding(EdgeInsets(top: 40, leading: 0, bottom: 1, trailing: 0))
         }
+        // view가 보일때 singingListToggle 배열 false로 초기화
         .onAppear(perform: {
             for i in singingList {
                 singingListToggle[i.id!] = false

--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -11,6 +11,7 @@ struct SongDetailView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \SingingList.timestamp, ascending: true)], animation: .default) private var singingList: FetchedResults<SingingList>
     @State var refresh: Bool = false
+    @State private var refreshingID = UUID()
     var song: Song
     
     // 싱잉리스트 추가 sheet
@@ -62,8 +63,9 @@ struct SongDetailView: View {
                     
                     // TODO: - 해당 노래에 맞는 싱잉리스트로 받아오게 수정되어야 함
                     ForEach(song.singingListArray) {
-                        singingListTag(title: $0.title ?? "제목 없음")
+                        singingListTag(singingList: $0)
                     }
+                    .id(refreshingID)
                 }
                 
                 // MARK: - 상단 네비게이션 바 삭제 버튼
@@ -90,17 +92,26 @@ struct SongDetailView: View {
     }
     
     @ViewBuilder
-    func singingListTag(title: String) -> some View {
+    func singingListTag(singingList: SingingList) -> some View {
         HStack {
             Button {
-                print("싱잉리스트 태그 삭제하기")
+                song.removeFromSongToSingingList(singingList)
+                do {
+                    try viewContext.save()
+                    self.refreshingID = UUID()
+//                    refresh.toggle()
+
+                } catch {
+                    print(error.localizedDescription)
+                }
+                print("\(singingList.title ?? "제목 없음") 싱잉리스트 태그 삭제하기2")
             } label: {
                 Image(systemName: "minus.circle.fill")
                     .foregroundColor(.grayScale4)
                     .padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 10))
             }
             HStack {
-                Text(title)
+                Text(singingList.title ?? "제목 없음")
                     .font(.system(size: 20, weight: .semibold))
                     .foregroundColor(.white)
             }


### PR DESCRIPTION
## 작업사항

- 새로운 Song, SingingList CoreData에 저장시 기존에 중복된 데이터가 있는지 검사 후에 저장되게 로직 구현
- SongDetailView에서 해당 Song의 SingingLIst태그 삭제 로직 구현, 삭제 후 뷰 refresh되게 구현

## 이슈 번호

#61 
#62
