### PR TITLE
Feat/edit song detail view

### DIFF
--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -27,7 +27,7 @@ struct AddSingingListTagView: View {
                 Button(action: {
                     NavigationUtil.popToRootView()
                 }, label: {
-                    ConfirmButtonView(buttonName: "확인", buttonColor: Color.mainPurpleColor, textColor: .white)
+                    ConfirmButtonView(buttonName: "확인", buttonColor: isTextFieldFocused ? .black : Color.mainPurpleColor, textColor: isTextFieldFocused ? .black : .white)
                         .padding(.bottom, 60)
                 })
             }

--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -13,6 +13,7 @@ struct SongDetailView: View {
     @State var refresh: Bool = false
     @State private var refreshingID = UUID()
     @State private var isChanged = false
+    @State private var showDeleteAlert: Bool = false
     var song: Song
     
     // 싱잉리스트 추가 sheet
@@ -44,7 +45,7 @@ struct SongDetailView: View {
             
             VStack {
                 SongInfoView(song: song)
-                    .padding(.bottom, 52)
+                    .padding(.bottom, 20)
                 
                 ScrollView {
                     LevelPickerView(levelIndexBase: $levelPickerIndex, levelItems: levelPickerItems)
@@ -71,30 +72,44 @@ struct SongDetailView: View {
                         EditButtonView(buttonName: "추가하기", buttonWidth: 80){
                             isPresented.toggle()
                         }
-                            .padding(EdgeInsets(top: 16, leading: 0, bottom: 0, trailing: 34))
-                            .onChange(of: song.singingListArray, perform: { _ in
-                                isChanged = true
-                                print("changed")
-                            })
+                        .padding(EdgeInsets(top: 16, leading: 0, bottom: 0, trailing: 34))
+                        .onChange(of: song.singingListArray, perform: { _ in
+                            isChanged = true
+                            print("changed")
+                        })
                     }
                     
                     ForEach(song.singingListArray) {
                         singingListTag(singingList: $0)
                     }
                     .id(refreshingID)
+                    
+                    Button(action: {
+                        print("노래 삭제하기")
+                        self.showDeleteAlert = true
+                    }, label: {
+                        ConfirmButtonView(buttonName: "노래 삭제하기", buttonColor: Color.grayScale7.opacity(0.2), textColor: .red)
+                            .padding(.top, 30)
+                    })
+                    .alert("이 노래를 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
+                        Button("취소", role: .cancel) {}
+                        Button("삭제", role: .destructive) {
+                            // TODO: - 노래 데이터 삭제 코드
+                        }
+                    }
                 }
                 
-                // MARK: - 상단 네비게이션 바 삭제 버튼
+                // MARK: - 상단 네비게이션 바 저장 버튼
                 
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        Button{
+                        EditButtonView(buttonName: "저장", buttonWidth: 50) {
                             print("기록 저장하기")
-                        } label: {
-                            EditButtonView(buttonName: "저장", buttonWidth: 50){}
-                                .padding(.trailing, 20)
-                                .opacity(0.2)
+                            isChanged = false
                         }
+                        .padding(.trailing, 20)
+                        .opacity(isChanged == true ? 1 : 0.2)
+                        .disabled(!isChanged)
                     }
                 }
                 .padding(.bottom, 100)
@@ -102,6 +117,19 @@ struct SongDetailView: View {
         }
         .sheet(isPresented: $isPresented) {
             SingingListSheetView(refresh: $refresh, isPresent: $isPresented, song: song)
+        }
+        .onChange(of: isPresented, perform: { _ in
+            refresh.toggle()
+        })
+        .onDisappear(perform: {
+            print("alert")
+            if isChanged == true { showDeleteAlert = true }
+        })
+        .alert("이 노래를 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
+            Button("취소", role: .cancel) {}
+            Button("삭제", role: .destructive) {
+                // TODO: - 노래 데이터 삭제 코드
+            }
         }
     }
     

--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -14,6 +14,7 @@ struct SongDetailView: View {
     @State private var refreshingID = UUID()
     @State private var isChanged = false
     @State private var showDeleteAlert: Bool = false
+    @State private var showSaveAlert: Bool = false
     var song: Song
     
     // 싱잉리스트 추가 sheet
@@ -123,13 +124,13 @@ struct SongDetailView: View {
         })
         .onDisappear(perform: {
             print("alert")
-            if isChanged == true { showDeleteAlert = true }
+            if isChanged == true { showSaveAlert = true }
         })
-        .alert("이 노래를 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
-            Button("취소", role: .cancel) {}
-            Button("삭제", role: .destructive) {
-                // TODO: - 노래 데이터 삭제 코드
+        .alert("변경사항을 저장하시겠습니까?", isPresented: $showSaveAlert) {
+            Button("저장", role: .cancel) {
+                // TODO: - 노래 데이터 변경사항 코어데이터에 저장하는 코드
             }
+            Button("아니요", role: .destructive) {}
         }
     }
     

--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -71,10 +71,10 @@ struct SongDetailView: View {
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button{
-                            print("기록 삭제하기")
+                            print("기록 저장하기")
                         } label: {
-                            EditButtonView(buttonName: "삭제", buttonWidth: 60){}
-                                .padding(.trailing, 15)
+                            EditButtonView(buttonName: "저장", buttonWidth: 50){}
+                                .padding(.trailing, 20)
                         }
                     }
                 }

--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -124,7 +124,9 @@ struct SongDetailView: View {
         })
         .onDisappear(perform: {
             print("alert")
-            if isChanged == true { showSaveAlert = true }
+            if isChanged == true {
+                showSaveAlert = true
+            }
         })
         .alert("변경사항을 저장하시겠습니까?", isPresented: $showSaveAlert) {
             Button("저장", role: .cancel) {

--- a/Semo/Views/SongDetail/SongInfoView.swift
+++ b/Semo/Views/SongDetail/SongInfoView.swift
@@ -8,14 +8,16 @@
 import SwiftUI
 
 struct SongInfoView: View {
+    var song: Song
+    
     var body: some View {
         VStack {
             Spacer()
                 .frame(height: 70)
-            Text("노래 제목입니다")
+            Text(song.title ?? "제목 없음")
                 .font(.system(size: 24, weight: .semibold))
                 .foregroundColor(.white)
-            Text("노래 가수입니다")
+            Text(song.singer ?? "가수 없음")
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(.grayScale2)
                 .padding(EdgeInsets(top: 2, leading: 0, bottom: 0, trailing: 0))
@@ -23,8 +25,8 @@ struct SongInfoView: View {
     }
 }
 
-struct SongInfoView_Previews: PreviewProvider {
-    static var previews: some View {
-        SongInfoView().preferredColorScheme(.dark)
-    }
-}
+//struct SongInfoView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SongInfoView().preferredColorScheme(.dark)
+//    }
+//}


### PR DESCRIPTION
![Simulator Screen Recording - iPhone 13 - 2022-09-16 at 02 21 28](https://user-images.githubusercontent.com/98628614/190471392-2e47f1c3-7cab-4d85-9341-0e48aaa288f9.gif)

## 작업사항
- [hotfix] AddSingingListTagView에서 키보드 올라왔을때 뒤에 버튼 가리기
- SongDetailView 삭제 버튼을 저장 버튼으로 변경
- 값이 변경되었을 때 저장 버튼 활성화
- SongDetailView 하단에 삭제 버튼 추가, 삭제 시 alert 뜨기
- SongDetailView에 가수, 제목 불러오기
- 짜잘한 패딩값 수정

<!--- 작업 사항들의 간단한 설명들을 작성해주세요. -->

## 이슈 번호
#58 #67 
<!-- 이슈 번호를 연결해주세요. -->


## 특이사항 (optional)
변경사항을 저장하지 않은 채로 뒤로가기 버튼을 누르면 alert이 떠야하는데,
swiftUI에는 viewWillDisappear가 없더라구요.
UIkit을 가져올지, custom back button을 만들어야 할지 같이 고민이 필요합니다!
<!--- 특이 사항이 있으시면 작성해주세요. -->
