### PR TITLE
refactor/textfieldBlankDetection >>> 텍스트 필드 공백 및 문자열 앞뒤 공백 제거

### DIFF
--- a/Semo/Views/AddSong/AddMoreInfoView.swift
+++ b/Semo/Views/AddSong/AddMoreInfoView.swift
@@ -49,6 +49,7 @@ struct AddMoreInfoView: View {
                 Button(action: {
                     // 네비게이션 빠져 나오게
                     NavigationUtil.popToRootView()
+                    
                     // 노래 추가 로직
                     CoreDataManager.shared.saveNewSong(songTitle: songTitle, songSinger: songSinger)
 

--- a/Semo/Views/Others/TextFieldView.swift
+++ b/Semo/Views/Others/TextFieldView.swift
@@ -24,6 +24,7 @@ struct TextFieldView: View {
         HStack {
             TextField("", text: $text, onEditingChanged: { changed in
                 self.isEditing = changed
+                text = text.trimmingCharacters(in: .whitespacesAndNewlines)
             })
             .placeholder(when: text.isEmpty) {
                 Text("\(placeholder)")


### PR DESCRIPTION
## 작업사항
![Simulator Screen Recording - iPhone 13 - 2022-09-20 at 02 38 05](https://user-images.githubusercontent.com/52993882/191079634-bcb412a5-5b5c-475d-8385-1bd45fc055b3.gif)

텍스트 필드 공백 및 스트링 앞뒤 공백 예외처리 해줬습니당 

## 이슈 번호
#77 

## 특이사항 (optional)
- 리프레쉬 코드가 필요합니다
- 저장이 addSongView와 addMoreInfoView에 둘다 작성되어있는데 두번째 뷰에서만 저장되면 될거 같습니다!
