### PR TITLE
[hotfix] AddSong 플로우에서 정보 저장하는 코드 수정

### DIFF
--- a/Semo/Managers/CoreDataManager.swift
+++ b/Semo/Managers/CoreDataManager.swift
@@ -59,7 +59,7 @@ class CoreDataManager {
                 newSong.level = level
                 newSong.tune = tune
                 try viewContext.save()
-                print("title : \(songTitle), singer : \(songSinger) 저장 완료")
+                print("title : \(songTitle), singer : \(songSinger), gender : \(gender), level : \(level), tune : \(tune) 저장 완료")
                 return
             }
             print("[중복 노래] title : \(songTitle), singer : \(songSinger) 저장 불가")

--- a/Semo/Views/AddSong/AddMoreInfoView.swift
+++ b/Semo/Views/AddSong/AddMoreInfoView.swift
@@ -16,7 +16,7 @@ struct AddMoreInfoView: View {
     var genderItems = ["여성", "혼성", "남성"]
     @State var genderIndex = "혼성"
     
-    @State var tunePickerIndex:Int = 6
+    @State var tunePickerIndex: Int = 6
     @State var tunePickerItems: [String] = ["-6", "-5", "-4", "-3", "-2", "-1",
                                             "0", "1", "2", "3", "4", "5", "6"]
     
@@ -36,22 +36,26 @@ struct AddMoreInfoView: View {
                     .foregroundColor(.white)
                     .font(.system(size: 24, weight: .semibold))
                     .padding(EdgeInsets(top: 14, leading: 20, bottom: 0, trailing: 0))
+                
                 LevelPickerView(levelIndexBase: $levelPickerIndex, levelItems: levelPickerItems)
                     .padding(.top, 60)
+                
                 TunePickerView(genderIndexBase: $genderIndex, genderItems: genderItems, tuneIndexBase: $tunePickerIndex, tuneItems: tunePickerItems)
+                
                 Spacer()
                 
-                // TODO: - 데이터 저장하고 다음 단계로 넘어가기
-                NavigationLink(destination: AddSingingListTagView(songTitle: songTitle, songSinger: songSinger)) {
+                // MARK: - 확인버튼
+                NavigationLink(destination: AddSingingListTagView(songTitle: songTitle, songSinger: songSinger, gender: genderIndex, level: levelPickerItems[levelPickerIndex], tune: tunePickerItems[tunePickerIndex])) {
                     ConfirmButtonView(buttonName: "확인", buttonColor: Color.mainPurpleColor, textColor: .white)
                 }
                 .navigationTitle("")
+                
+                // MARK: - 건너뛰기 버튼
                 Button(action: {
                     // 네비게이션 빠져 나오게
                     NavigationUtil.popToRootView()
                     // 노래 추가 로직
                     CoreDataManager.shared.saveNewSong(songTitle: songTitle, songSinger: songSinger)
-
                 }, label: {
                     Text("건너뛰기")
                         .foregroundColor(.grayScale1)
@@ -63,9 +67,3 @@ struct AddMoreInfoView: View {
         .navigationBarTitle("", displayMode: .inline)
     }
 }
-
-//struct AddMoreInfoView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        AddMoreInfoView().preferredColorScheme(.dark)
-//    }
-//}

--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -15,16 +15,21 @@ struct AddSingingListTagView: View {
     
     var songTitle: String
     var songSinger: String
+    var gender: String
+    var level: String
+    var tune: String
     
     var body: some View {
         ZStack {
             Color.backgroundBlack.ignoresSafeArea()
             LinearGradient(gradient: Gradient(colors: [Color.grayScale6, Color.backgroundBlack]), startPoint: .top, endPoint: UnitPoint(x: 0.5, y: 0.3))
             .edgesIgnoringSafeArea(.all)
+            
             // MARK: - main으로 연결되는 확인 버튼
             VStack {
                 Spacer()
                 Button(action: {
+                    // TODO: - SingingList를 Song에 추가하는 함수 넣기
                     NavigationUtil.popToRootView()
                 }, label: {
                     ConfirmButtonView(buttonName: "확인", buttonColor: isTextFieldFocused ? .black : Color.mainPurpleColor, textColor: isTextFieldFocused ? .black : .white)
@@ -32,6 +37,7 @@ struct AddSingingListTagView: View {
                 })
             }
             .ignoresSafeArea(.keyboard)
+            
             // MARK: - 타이틀 및 싱잉리스트 뷰
             VStack(alignment: .center) {
                 Text("이 노래가 들어갈 싱잉리스트를 \n선택해주세요.")
@@ -55,11 +61,11 @@ struct AddSingingListTagView: View {
                 .padding(.bottom, 120)
             }
             .ignoresSafeArea(.keyboard)
-            // MARK: - 키보드가 올라왔을 때 보이는 추가 버튼
+            
+            // MARK: - 키보드가 올라왔을 때 보이는 singingList 추가 버튼
             VStack {
                 Spacer()
                 if isTextFieldFocused == true {
-                    // TODO: - textField가 focus되지 않았을 때 버튼 회색으로 변경
                     Button(action: {
                         // 새로운 SingingList coreData에 추가
                         CoreDataManager.shared.saveNewSingingList( singingListTitle: newSingingListTitle)
@@ -81,13 +87,7 @@ struct AddSingingListTagView: View {
         })
         .onDisappear(perform: {
             // 노래 추가 로직
-            CoreDataManager.shared.saveNewSong(songTitle: songTitle, songSinger: songSinger)
+            CoreDataManager.shared.saveNewSong(songTitle: songTitle, songSinger: songSinger, gender: gender, level: level, tune: tune)
         })
     }
 }
-
-//struct AddSingingListTagView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        AddSingingListTagView()
-//    }
-//}

--- a/Semo/Views/AddSong/AddSongView.swift
+++ b/Semo/Views/AddSong/AddSongView.swift
@@ -25,9 +25,6 @@ struct AddSongView: View {
                     .foregroundColor(.white)
                     .font(.system(size: 24, weight: .semibold))
                     .padding(EdgeInsets(top: 14, leading: 10, bottom: 0, trailing: 0))
-                //                    .padding(.leading, 10)
-                //                    .padding(.top, 14)
-                
                 
                 Text("노래 제목")
                     .font(.system(size: 15, weight: .medium))
@@ -38,7 +35,6 @@ struct AddSongView: View {
                     .frame(width: UIScreen.main.bounds.width - 20, height: 20)
                     .disableAutocorrection(true)
                 
-                
                 Text("가수 이름")
                     .font(.system(size: 15, weight: .medium))
                     .padding(EdgeInsets(top: 40, leading: 10, bottom: 0, trailing: 0))
@@ -48,18 +44,16 @@ struct AddSongView: View {
                     .frame(width: UIScreen.main.bounds.width - 20, height: 20)
                     .disableAutocorrection(true)
                 
-                Button(action: {
-                    CoreDataManager.shared.saveNewSong(songTitle: songTitle, songSinger: songSinger)
-                }, label: {
-                    NavigationLink(destination: AddMoreInfoView(songTitle: songTitle, songSinger: songSinger)) {
-                        ConfirmButtonView(buttonName: "확인",
-                                          buttonColor: songTitle.isEmpty || songSinger.isEmpty ? .grayScale5 : Color.mainPurpleColor,
-                                          textColor: songTitle.isEmpty || songSinger.isEmpty ? .grayScale3 : .white)
-                    }
-                    .padding(EdgeInsets(top: 50, leading: 10, bottom: 0, trailing: 0))
-                    .navigationBarTitleDisplayMode(.inline)
-                    .disabled(self.songTitle.isEmpty || self.songSinger.isEmpty)
-                })
+                // MARK: - 확인 버튼
+                NavigationLink(destination: AddMoreInfoView(songTitle: songTitle, songSinger: songSinger)) {
+                    ConfirmButtonView(buttonName: "확인",
+                                      buttonColor: songTitle.isEmpty || songSinger.isEmpty ? .grayScale5 : Color.mainPurpleColor,
+                                      textColor: songTitle.isEmpty || songSinger.isEmpty ? .grayScale3 : .white)
+                }
+                .padding(EdgeInsets(top: 50, leading: 10, bottom: 0, trailing: 0))
+                .navigationBarTitleDisplayMode(.inline)
+                .disabled(self.songTitle.isEmpty || self.songSinger.isEmpty)
+                
                 Spacer()
             }
             .padding()


### PR DESCRIPTION
## 작업사항
- AddSongView에서 정보 저장 함수 삭제
- AddMoreInfoView에서 tune, level, gender값 넘겨주기
- AddSingingListTagView 사라질 때 정보 코어데이터에 저장하기
- CoreDataManager saveNewSong함수에서 저장되었는지 확인하기 위한 print문 수정
- 코드 리팩토링

<!--- 작업 사항들의 간단한 설명들을 작성해주세요. -->

## 이슈 번호
#79 

<!-- 이슈 번호를 연결해주세요. -->


## 특이사항 (optional)
- SingingListTag를 Song에 추가하는 함수가 필요합니다. (AddSingingListTagView에 todo 써있는 곳에서 사용)
- 코어데이터 저장될 때 뷰 refresh 코드 필요합니다

<!--- 특이 사항이 있으시면 작성해주세요. -->
