### PR TITLE
[fix] #91 노래 추가후 메인뷰 동기화 && 네비게이션 핑퐁 현상 해결

### DIFF
--- a/Semo/Views/AddSong/AddMoreInfoView.swift
+++ b/Semo/Views/AddSong/AddMoreInfoView.swift
@@ -20,6 +20,9 @@ struct AddMoreInfoView: View {
     @State var tunePickerItems: [String] = ["-6", "-5", "-4", "-3", "-2", "-1",
                                             "0", "1", "2", "3", "4", "5", "6"]
     
+    @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
+    @Binding var isPopToRoot: Bool
+    
     var songTitle: String
     var songSinger: String
     
@@ -28,7 +31,9 @@ struct AddMoreInfoView: View {
             Color.backgroundBlack.ignoresSafeArea()
             LinearGradient(gradient: Gradient(colors: [Color.grayScale6, Color.backgroundBlack]), startPoint: .top, endPoint: UnitPoint(x: 0.5, y: 0.3))
             .edgesIgnoringSafeArea(.all)
+            
             // MARK: - 추가 정보 입력란
+            
             VStack(alignment: .center) {
                 Text("노래방에서 필요한 정보를 \n입력하세요.")
                     .lineSpacing(10)
@@ -45,17 +50,20 @@ struct AddMoreInfoView: View {
                 Spacer()
                 
                 // MARK: - 확인버튼
-                NavigationLink(destination: AddSingingListTagView(songTitle: songTitle, songSinger: songSinger, gender: genderIndex, level: levelPickerItems[levelPickerIndex], tune: tunePickerItems[tunePickerIndex])) {
+                
+                NavigationLink(destination: AddSingingListTagView(isPopToRoot: $isPopToRoot, songTitle: songTitle, songSinger: songSinger, gender: genderIndex, level: levelPickerItems[levelPickerIndex], tune: tunePickerItems[tunePickerIndex])) {
                     ConfirmButtonView(buttonName: "확인", buttonColor: Color.mainPurpleColor, textColor: .white)
                 }
+                .isDetailLink(false)
                 .navigationTitle("")
                 
                 // MARK: - 건너뛰기 버튼
+                
                 Button(action: {
-                    // 네비게이션 빠져 나오게
-                    NavigationUtil.popToRootView()
+                    // 루트로 회귀
+                    self.isPopToRoot = false
                     
-                    // 노래 추가 로직
+                    // 노래 추가
                     CoreDataManager.shared.saveNewSong(songTitle: songTitle, songSinger: songSinger)
                 }, label: {
                     Text("건너뛰기")

--- a/Semo/Views/AddSong/AddSingingListTagView.swift
+++ b/Semo/Views/AddSong/AddSingingListTagView.swift
@@ -11,7 +11,9 @@ struct AddSingingListTagView: View {
     @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \SingingList.timestamp, ascending: true)], animation: .linear) private var singingList: FetchedResults<SingingList>
     @State var newSingingListTitle: String = ""
     @State var singingListToggle: [UUID: Bool] = [:]
+    @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
     @FocusState private var isTextFieldFocused: Bool
+    @Binding var isPopToRoot: Bool
     
     var songTitle: String
     var songSinger: String
@@ -26,11 +28,12 @@ struct AddSingingListTagView: View {
             .edgesIgnoringSafeArea(.all)
             
             // MARK: - main으로 연결되는 확인 버튼
+            
             VStack {
                 Spacer()
                 Button(action: {
-                    // TODO: - SingingList를 Song에 추가하는 함수 넣기
-                    NavigationUtil.popToRootView()
+                    self.isPopToRoot = false
+                    CoreDataManager.shared.saveNewSong(songTitle: songTitle, songSinger: songSinger, gender: gender, level: level, tune: tune)
                 }, label: {
                     ConfirmButtonView(buttonName: "확인", buttonColor: isTextFieldFocused ? .black : Color.mainPurpleColor, textColor: isTextFieldFocused ? .black : .white)
                         .padding(.bottom, 60)
@@ -39,6 +42,7 @@ struct AddSingingListTagView: View {
             .ignoresSafeArea(.keyboard)
             
             // MARK: - 타이틀 및 싱잉리스트 뷰
+            
             VStack(alignment: .center) {
                 Text("이 노래가 들어갈 싱잉리스트를 \n선택해주세요.")
                     .lineSpacing(10)
@@ -63,12 +67,13 @@ struct AddSingingListTagView: View {
             .ignoresSafeArea(.keyboard)
             
             // MARK: - 키보드가 올라왔을 때 보이는 singingList 추가 버튼
+            
             VStack {
                 Spacer()
                 if isTextFieldFocused == true {
                     Button(action: {
                         // 새로운 SingingList coreData에 추가
-                        CoreDataManager.shared.saveNewSingingList( singingListTitle: newSingingListTitle)
+                        CoreDataManager.shared.saveNewSingingList(singingListTitle: newSingingListTitle)
                         newSingingListTitle = ""
                         isTextFieldFocused = false
                     }, label: {
@@ -84,10 +89,6 @@ struct AddSingingListTagView: View {
             for i in singingList {
                 singingListToggle.updateValue(false, forKey: i.id!)
             }
-        })
-        .onDisappear(perform: {
-            // 노래 추가 로직
-            CoreDataManager.shared.saveNewSong(songTitle: songTitle, songSinger: songSinger, gender: gender, level: level, tune: tune)
         })
     }
 }

--- a/Semo/Views/AddSong/AddSongView.swift
+++ b/Semo/Views/AddSong/AddSongView.swift
@@ -13,6 +13,7 @@ struct AddSongView: View {
     @State var songTitle: String = ""
     @State var songSinger: String = ""
     @State var emptyFlag: Bool = false
+    @Binding var isPopToRoot: Bool
     
     var body: some View {
         ZStack {
@@ -45,11 +46,13 @@ struct AddSongView: View {
                     .disableAutocorrection(true)
                 
                 // MARK: - 확인 버튼
-                NavigationLink(destination: AddMoreInfoView(songTitle: songTitle, songSinger: songSinger)) {
+                
+                NavigationLink(destination: AddMoreInfoView(isPopToRoot: $isPopToRoot, songTitle: songTitle, songSinger: songSinger)) {
                     ConfirmButtonView(buttonName: "확인",
                                       buttonColor: songTitle.isEmpty || songSinger.isEmpty ? .grayScale5 : Color.mainPurpleColor,
                                       textColor: songTitle.isEmpty || songSinger.isEmpty ? .grayScale3 : .white)
                 }
+                .isDetailLink(false)
                 .padding(EdgeInsets(top: 50, leading: 10, bottom: 0, trailing: 0))
                 .navigationBarTitleDisplayMode(.inline)
                 .disabled(self.songTitle.isEmpty || self.songSinger.isEmpty)
@@ -59,11 +62,5 @@ struct AddSongView: View {
             .padding()
             .navigationBarTitle("", displayMode: .inline)
         }
-    }
-}
-
-struct AddSongView_Previews: PreviewProvider {
-    static var previews: some View {
-        AddSongView()
     }
 }

--- a/Semo/Views/AllSongList/SongListView.swift
+++ b/Semo/Views/AllSongList/SongListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SongListView: View {
-    @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
+    @Binding var songList: [Song]
     @Binding var refresh: Int
     @Binding var songEditButtonTap: Bool
     
@@ -49,6 +49,9 @@ struct SongListView: View {
             songList = CoreDataManager.shared.fetchSongList() ?? []
             print("노래 편집")
         })
+        .onAppear{
+            songList = CoreDataManager.shared.fetchSongList() ?? []
+        }
         .onDisappear {
             self.songEditButtonTap = false
         }

--- a/Semo/Views/MainView.swift
+++ b/Semo/Views/MainView.swift
@@ -8,10 +8,16 @@
 import SwiftUI
 
 struct MainView: View {
+    @State private var showSingingListModal: Bool = false
     @State var currentTab: Int = 0
     @State var songEditButtonTapped: Bool = false
     @State var listEditButtonTapped: Bool = false
+    @State var isPopToRoot: Bool = false
     @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
+    
+    @Namespace var namespace
+    
+    var tabBarOptions: [String] = ["전체 노래", "싱잉리스트"]
     
     // MARK: - BODY
     var body: some View {
@@ -20,17 +26,59 @@ struct MainView: View {
                 Image("backgroundImage")
                     .ignoresSafeArea()
                 
-                // MARK: - 상단 탭바
+                // MARK: - 상단 TabBar
+                // -------------------------------------------
+                
                 TabView(selection: self.$currentTab) {
-                    SongListView(refresh: $currentTab, songEditButtonTap: $songEditButtonTapped).tag(0)
+                    SongListView(songList: $songList, refresh: $currentTab, songEditButtonTap: $songEditButtonTapped).tag(0)
                     SingingListView(refresh: $currentTab, songEditButtonTapped: $songEditButtonTapped, listEditButtonTapped: $listEditButtonTapped).tag(1)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
                 .edgesIgnoringSafeArea(.all)
                 .navigationBarTitle("", displayMode: .inline)
                 
-                TabBarView(currentTab: self.$currentTab)
-                    .padding(.top, 60)
+                
+                // MARK: 커스텀된 TabBar 메뉴 버튼
+                
+                HStack {
+                    HStack {
+                        ForEach(Array(zip(self.tabBarOptions.indices,
+                                          self.tabBarOptions)),
+                                id: \.0,
+                                content: { index, name in
+                            TabBarItemView(tabBarItemName: name,
+                                           currentTab: self.$currentTab,
+                                           namespace: namespace.self,
+                                           tab: index)
+                        })
+                    }
+                    Spacer()
+                    
+                    // MARK: 우측 상단 노래 및 리스트 추가 버튼
+                    
+                    if tabBarOptions[currentTab] == "전체 노래" {
+                        NavigationLink(destination: AddSongView(isPopToRoot: $isPopToRoot), isActive: self.$isPopToRoot) {
+                            Image("Songlistbuttonimage")
+                        }
+                        .isDetailLink(false)
+                    } else {
+                        Button {
+                            self.showSingingListModal = true
+                        } label: {
+                            Image(tabBarOptions[currentTab] == "전체 노래" ? "Songlistbuttonimage" : "Singinglistbuttonimage")
+                        }
+                        .sheet(isPresented: $showSingingListModal) {
+                            SingingListModalView()
+                        }
+                    }
+                }
+                .padding(EdgeInsets(top: 120, leading: 10, bottom: 0, trailing: 24))
+                // FIXME: - background 생략시 탭바가 아래로 밀리는 현상 발생
+                .background(.clear)
+                .frame(height: 32)
+                
+                // -------------------------------------------
+
             }
             .navigationBarHidden(true)
         }

--- a/Semo/Views/SingingListDetail/AddSongButtonView.swift
+++ b/Semo/Views/SingingListDetail/AddSongButtonView.swift
@@ -8,13 +8,14 @@
 import SwiftUI
 
 struct AddSongButtonView: View {
+    @Binding var isPopToRoot: Bool
     // MARK: - BODY
     var body: some View {
         HStack {
             Button {
             } label: {
                 // TODO: - destination 수정 필요
-                NavigationLink(destination: AddSongView()) {
+                NavigationLink(destination: AddSongView(isPopToRoot: $isPopToRoot)) {
                     Label {
                         Text("노래 추가하기")
                             .font(.system(size: 18, weight: .medium))
@@ -32,8 +33,8 @@ struct AddSongButtonView: View {
     }
 }
 
-struct AddSongButtonView_Previews: PreviewProvider {
-    static var previews: some View {
-        AddSongButtonView()
-    }
-}
+//struct AddSongButtonView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        AddSongButtonView()
+//    }
+//}

--- a/Semo/Views/TabBar/TabBarView.swift
+++ b/Semo/Views/TabBar/TabBarView.swift
@@ -32,9 +32,9 @@ struct TabBarView: View {
             Spacer()
             // MARK: - 탭바 우측 노래 리스트 추가 버튼
             if tabBarOptions[currentTab] == "전체 노래" {
-                NavigationLink(destination: AddSongView()) {
-                    Image("Songlistbuttonimage")
-                }
+//                NavigationLink(destination: AddSongView()) {
+//                    Image("Songlistbuttonimage")
+//                }
             } else {
                 Button {
                     self.showSingingListModal = true


### PR DESCRIPTION
## 작업사항

![Simulator Screen Recording - iPhone 13 - 2022-09-30 at 01 47 20](https://user-images.githubusercontent.com/52993882/193090943-e2cc37fd-8e3e-4b8a-8dfe-09cbc772c4d7.gif)

- TabBarView를 MainView내로 따로 빼서 구현했습니다
- 노래 추가시 메인뷰가 리로드 되지 않는 현상을 해결했습니다.
- 노래 추가후 메인뷰로 이동시 생기는 네비게이션 핑퐁현상을 해결했습니다.

## 이슈 번호

#91 


## 특이사항 (optional)

- 이제 메인뷰에서 노래 상세 정보를 불러와서 보여주기만 하면 됩니다.
