### PR TITLE
feat/EditSongDetailView >> 저장된 노래 상세 정보 디테일뷰에서 보여주기, 노래 삭제 함수 디테일 뷰에 추가

### DIFF
--- a/Semo/Views/AllSongList/SongListCellView.swift
+++ b/Semo/Views/AllSongList/SongListCellView.swift
@@ -23,7 +23,7 @@ struct SongListCellView: View {
                         .transition(.move(edge: .leading))
                         .animation(.easeInOut)
                 }
-                NavigationLink(destination: SongDetailView(song: song, genderIndex: song.gender!, levelPickerIndex: ["하", "중", "상"].firstIndex(of: song.level ?? "중") ?? 1, tunePickerIndex: ["-6", "-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5", "6"].firstIndex(of: song.tune ?? "0") ?? 0)) {
+                NavigationLink(destination: SongDetailView(song: song, genderIndex: song.gender ?? "혼성", levelPickerIndex: ["하", "중", "상"].firstIndex(of: song.level ?? "중") ?? 1, tunePickerIndex: ["-6", "-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5", "6"].firstIndex(of: song.tune ?? "0") ?? 0)) {
                     // MARK: - 노래 정보 표시
                     VStack(alignment: .leading, spacing: 10) {
                         Text(song.title ?? "제목 없음")

--- a/Semo/Views/AllSongList/SongListCellView.swift
+++ b/Semo/Views/AllSongList/SongListCellView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SongListCellView: View {
     @Binding var editButtonTapped: Bool
     var song: Song
+    
     // MARK: - BODY
     var body: some View {
         Button {
@@ -22,7 +23,7 @@ struct SongListCellView: View {
                         .transition(.move(edge: .leading))
                         .animation(.easeInOut)
                 }
-                NavigationLink(destination: SongDetailView(song: song)) {
+                NavigationLink(destination: SongDetailView(song: song, genderIndex: song.gender!, levelPickerIndex: ["하", "중", "상"].firstIndex(of: song.level ?? "중") ?? 1, tunePickerIndex: ["-6", "-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5", "6"].firstIndex(of: song.tune ?? "0") ?? 0)) {
                     // MARK: - 노래 정보 표시
                     VStack(alignment: .leading, spacing: 10) {
                         Text(song.title ?? "제목 없음")

--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -103,6 +103,7 @@ struct SongDetailView: View {
                         Button("취소", role: .cancel) {}
                         Button("삭제", role: .destructive) {
                             CoreDataManager.shared.deleteSong(song: song)
+                            self.presentationMode.wrappedValue.dismiss()
                         }
                     }
                 }

--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -17,20 +17,19 @@ struct SongDetailView: View {
     @State private var isChanged = false
     @State private var showDeleteAlert: Bool = false
     @State private var showSaveAlert: Bool = false
+    @State private var isPresented = false // 싱잉리스트 추가 sheet
     
     var song: Song
-    
-    // 싱잉리스트 추가 sheet
-    @State private var isPresented = false
-    @State var levelPickerIndex: Int = 1
     var levelPickerItems: [String] = ["하", "중", "상"]
-    
     var genderItems = ["여성", "혼성", "남성"]
-    @State var genderIndex = "혼성"
-    
-    @State var tunePickerIndex: Int = 6
     var tunePickerItems: [String] = ["-6", "-5", "-4", "-3", "-2", "-1",
                                      "0", "+1", "+2", "+3", "+4", "+5", "+6"]
+    
+    @State var genderIndex: String
+    
+    @State var levelPickerIndex: Int
+    
+    @State var tunePickerIndex: Int
     
     // MARK: - BODY
     
@@ -54,7 +53,9 @@ struct SongDetailView: View {
                 ScrollView {
                     LevelPickerView(levelIndexBase: $levelPickerIndex, levelItems: levelPickerItems)
                         .onChange(of: levelPickerIndex, perform: { _ in
-                            isChanged = true
+                            if levelPickerItems[levelPickerIndex] != song.level {
+                                isChanged = true
+                            }
                             print("changed")
                         })
                     
@@ -62,11 +63,15 @@ struct SongDetailView: View {
                     // TODO: Padding 세부 간격 조절 필요
                         .padding(.bottom, 42)
                         .onChange(of: genderIndex, perform: { _ in
-                            isChanged = true
+                            if genderIndex != song.gender {
+                                isChanged = true
+                            }
                             print("changed")
                         })
                         .onChange(of: tunePickerIndex, perform: { _ in
-                            isChanged = true
+                            if tunePickerItems[tunePickerIndex] != song.tune {
+                                isChanged = true
+                            }
                             print("changed")
                         })
                     
@@ -99,7 +104,7 @@ struct SongDetailView: View {
                     .alert("이 노래를 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
                         Button("취소", role: .cancel) {}
                         Button("삭제", role: .destructive) {
-                            // TODO: - 노래 데이터 삭제 코드
+                            CoreDataManager.shared.deleteSong(song: song)
                         }
                     }
                 }
@@ -109,7 +114,8 @@ struct SongDetailView: View {
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         EditButtonView(buttonName: "저장", buttonWidth: 50) {
-                            // TODO: - 노래 데이터 변경사항 코어데이터에 저장하는 코드
+                            // 노래 데이터 변경사항 코어데이터에 저장하는 코드
+                            CoreDataManager.shared.updateSongAdditionalInformation(song: song, gender: genderIndex, level: levelPickerItems[levelPickerIndex], tune: tunePickerItems[tunePickerIndex])
                             print("기록 저장하기")
                             isChanged = false
                         }
@@ -134,7 +140,8 @@ struct SongDetailView: View {
                                     self.presentationMode.wrappedValue.dismiss()
                                 }
                                 Button("저장", role: .none) {
-                                    // TODO: - 노래 데이터 변경사항 코어데이터에 저장하는 코드
+                                    // 노래 데이터 변경사항 코어데이터에 저장하는 코드
+                                    CoreDataManager.shared.updateSongAdditionalInformation(song: song, gender: genderIndex, level: levelPickerItems[levelPickerIndex], tune: tunePickerItems[tunePickerIndex])
                                     self.presentationMode.wrappedValue.dismiss()
                                 }
                             }
@@ -175,8 +182,6 @@ struct SongDetailView: View {
                 do {
                     try viewContext.save()
                     self.refreshingID = UUID()
-                    //                    refresh.toggle()
-                    
                 } catch {
                     print(error.localizedDescription)
                 }

--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -26,9 +26,7 @@ struct SongDetailView: View {
                                      "0", "+1", "+2", "+3", "+4", "+5", "+6"]
     
     @State var genderIndex: String
-    
     @State var levelPickerIndex: Int
-    
     @State var tunePickerIndex: Int
     
     // MARK: - BODY
@@ -113,7 +111,7 @@ struct SongDetailView: View {
                 
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        EditButtonView(buttonName: "저장", buttonWidth: 50) {
+                        SongEditButtonView(buttonName: "저장", buttonWidth: 50) {
                             // 노래 데이터 변경사항 코어데이터에 저장하는 코드
                             CoreDataManager.shared.updateSongAdditionalInformation(song: song, gender: genderIndex, level: levelPickerItems[levelPickerIndex], tune: tunePickerItems[tunePickerIndex])
                             print("기록 저장하기")


### PR DESCRIPTION
## 작업사항
![Simulator Screen Recording - iPhone 13 - 2022-09-30 at 03 08 31](https://user-images.githubusercontent.com/98628614/193110276-bfbcbbbb-893a-4c8a-9694-edba48c0b183.gif)

- 저장된 노래 상세 정보 디테일뷰에서 보여주기
- 노래 삭제 함수 디테일 뷰에 추가

## 이슈 번호
#80 
<!-- 이슈 번호를 연결해주세요. -->


## 특이사항 (optional)
- 디테일뷰에서 내용 수정했을 때 뷰 리프레시가 안됩니다.
- 노래 삭제하고 나서 뷰 리프레시가 안됩니다.
- 디테일 뷰에서 싱잉리스트는 변경 사항이 저장 버튼을 눌러야 반영이 되어야 하는데, 현재는 삭제나 추가하면 저장 버튼을 누르지 않아도 바로 코어데이터에 반영됩니다.
<!--- 특이 사항이 있으시면 작성해주세요. -->
