### PR TITLE
[2022.10.04] hotfix/FixTuneDefault >> song 추가정보 건너뛰기할 때 튠 버그 수정

### DIFF
--- a/Semo/Managers/CoreDataManager.swift
+++ b/Semo/Managers/CoreDataManager.swift
@@ -30,7 +30,7 @@ class CoreDataManager {
                 // 추가 정보
                 newSong.gender = "남키"
                 newSong.level = "중"
-                newSong.tune = "0"
+                newSong.tune = "+0"
                 try viewContext.save()
                 print("title : \(songTitle), singer : \(songSinger) 저장 완료")
                 return


### PR DESCRIPTION
## 작업사항
- song 추가정보 건너뛰기할 때 튠이 "0"으로 저장되는 것을 "+0"으로 수정
<!--- 작업 사항들의 간단한 설명들을 작성해주세요. -->

## 이슈 번호
#106 
<!-- 이슈 번호를 연결해주세요. -->
