### PR TITLE
[2022.10.04] feat/changeSingingListTitle >> 싱잉리스트 디테일 뷰 패딩값 조절 및 alert 기능 삭제

### DIFF
--- a/Semo.xcodeproj/xcuserdata/jungin-yoo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Semo.xcodeproj/xcuserdata/jungin-yoo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Semo.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Semo/Views/SingingListDetail/SingingListDetailView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailView.swift
@@ -13,6 +13,7 @@ struct SingingListDetailView: View {
     @State var isSingingListTitleEditing: Bool = false
     @State private var showSaveAlert: Bool = false
     @State var singingListViewFetch: Bool = false
+    @State var changedSingingListTitle: String = ""
     @Binding var songList: [Song]
     @Binding var listEditButtonTapped: Bool
     @Binding var songEditButtonTapped: Bool
@@ -51,7 +52,7 @@ struct SingingListDetailView: View {
                 .underlineTextField(isEditing: isSingingListTitleEditing, isFull: !singingListTitle.isEmpty, inset: 55, active: songEditButtonTapped)
                 .padding(EdgeInsets(top: 0, leading: 10, bottom: 600, trailing: 10))
                 SingingListDetailCellView(singingListViewFetch: $singingListViewFetch, songEditButtonTap: $songEditButtonTapped, singingList: singingList)
-                    .padding(.top, 35)
+                    .padding(.top, 60)
             }
             .ignoresSafeArea(.all)
         }
@@ -59,6 +60,7 @@ struct SingingListDetailView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 SongEditButtonView(buttonName: songEditButtonTapped == true ? "완료" : "편집", buttonWidth: 50) {
                     self.songEditButtonTapped.toggle()
+                    CoreDataManager.shared.updateSingingListTitle(title: singingListTitle, singingList: singingList)
                 }
                 .padding(.trailing, 20)
             }
@@ -72,7 +74,8 @@ struct SingingListDetailView: View {
                     .navigationBarBackButtonHidden(true)
                 } else {
                     Button {
-                        self.showSaveAlert = true
+                        // TODO: - 뷰 리프레시 필요
+                        self.songEditButtonTapped.toggle()
                         print("리스트 편집 그만하기")
                     } label: {
                         Image(systemName: "xmark")
@@ -80,15 +83,6 @@ struct SingingListDetailView: View {
                             .foregroundColor(.white)
                     }
                     .navigationBarBackButtonHidden(true)
-                    .alert("변경사항을 저장하시겠습니까?", isPresented: $showSaveAlert) {
-                        Button("아니요", role: .cancel) {
-                            self.presentationMode.wrappedValue.dismiss()
-                        }
-                        Button("저장", role: .none) {
-                            // TODO: - 리스트 데이터 변경사항 코어데이터에 저장하는 코드
-                            self.presentationMode.wrappedValue.dismiss()
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
## 작업사항
- 싱잉리스트 디테일 뷰 내 패딩값 조절했습니다
- 편집 활성화 시 생기는 X버튼에서 alert 기능 삭제했습니다

## 이슈 번호
#89 
<!-- 이슈 번호를 연결해주세요. -->


## 특이사항 (optional)
- X버튼 눌렀을 때 singinglisttitle이 수정 이전으로 돌아가야함
- 싱잉리스트 디테일 뷰 내 노래목록 따로 뷰 생성
- 리스트에서 노래 삭제시 전체 삭제가 아닌 리스트 내에서만 삭제되도록 구현
<!--- 특이 사항이 있으시면 작성해주세요. -->
