### PR TITLE
[2022.10.05] feat/AddSingingListUI >> 노래 리스트에서만 삭제하는 기능 추가

### DIFF
--- a/Semo.xcodeproj/project.pbxproj
+++ b/Semo.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		EEC3B553288408390036BE34 /* SingingListDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC3B552288408390036BE34 /* SingingListDetailView.swift */; };
 		EEC3B55728843AE80036BE34 /* AddSongButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC3B55628843AE80036BE34 /* AddSongButtonView.swift */; };
 		EEC3B55A288441590036BE34 /* SingingListDetailCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC3B559288441590036BE34 /* SingingListDetailCellView.swift */; };
+		EEDF24BB28ED5522005923EC /* DeleteFromSongToSingingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDF24BA28ED5522005923EC /* DeleteFromSongToSingingListView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -108,6 +109,7 @@
 		EEC3B552288408390036BE34 /* SingingListDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingingListDetailView.swift; sourceTree = "<group>"; };
 		EEC3B55628843AE80036BE34 /* AddSongButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSongButtonView.swift; sourceTree = "<group>"; };
 		EEC3B559288441590036BE34 /* SingingListDetailCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingingListDetailCellView.swift; sourceTree = "<group>"; };
+		EEDF24BA28ED5522005923EC /* DeleteFromSongToSingingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteFromSongToSingingListView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -326,6 +328,7 @@
 				EE6E6DE128A2738B004F030C /* SingingListModalView.swift */,
 				EEC3B552288408390036BE34 /* SingingListDetailView.swift */,
 				EEC3B559288441590036BE34 /* SingingListDetailCellView.swift */,
+				EEDF24BA28ED5522005923EC /* DeleteFromSongToSingingListView.swift */,
 				EEC3B55628843AE80036BE34 /* AddSongButtonView.swift */,
 			);
 			path = SingingListDetail;
@@ -454,6 +457,7 @@
 				EEC3B54C28839FB30036BE34 /* TabBarView.swift in Sources */,
 				EEAD17842882E4CD009388DD /* SingingListCellView.swift in Sources */,
 				B22FFAA628EC600400A49255 /* UIScreenViewExtension.swift in Sources */,
+				EEDF24BB28ED5522005923EC /* DeleteFromSongToSingingListView.swift in Sources */,
 				3992665628A1BD4D001849E6 /* TestDetailView.swift in Sources */,
 				EEAD177D2882BE63009388DD /* ColorExtension.swift in Sources */,
 				B262DD0D2883F86F00E1B527 /* SongDetailView.swift in Sources */,

--- a/Semo.xcodeproj/xcuserdata/jungin-yoo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Semo.xcodeproj/xcuserdata/jungin-yoo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Semo.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>2</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Semo/Views/AllSongList/DeleteSongButtonView.swift
+++ b/Semo/Views/AllSongList/DeleteSongButtonView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct DeleteSongButtonView: View {
     @State var showDeleteAlert: Bool = false
-    @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
     @Binding var songEditButtonTapped: Bool
     
     var song: Song

--- a/Semo/Views/AllSongList/DeleteSongButtonView.swift
+++ b/Semo/Views/AllSongList/DeleteSongButtonView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct DeleteSongButtonView: View {
     @State var showDeleteAlert: Bool = false
     @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
-    @Binding var songEditButtonTap: Bool
+    @Binding var songEditButtonTapped: Bool
     
     var song: Song
     
@@ -26,7 +26,7 @@ struct DeleteSongButtonView: View {
             Button("취소", role: .cancel) {}
             Button("삭제", role: .destructive) {
                 CoreDataManager.shared.deleteSong(song: song)
-                songEditButtonTap = false
+                songEditButtonTapped = false
             }
         }
     }

--- a/Semo/Views/AllSongList/SongListCellView.swift
+++ b/Semo/Views/AllSongList/SongListCellView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SongListCellView: View {
-    @Binding var songEditButtonTap: Bool
+    @Binding var songEditButtonTapped: Bool
     @Binding var refreshView: Bool
     
     var song: Song
@@ -18,8 +18,8 @@ struct SongListCellView: View {
         Button {
         } label: {
             HStack {
-                if songEditButtonTap == true {
-                    DeleteSongButtonView(songEditButtonTap: $songEditButtonTap, song: song)
+                if songEditButtonTapped == true {
+                    DeleteSongButtonView(songEditButtonTapped: $songEditButtonTapped, song: song)
                         .padding(.trailing, 8)
                         .transition(.move(edge: .leading))
                         .animation(.easeInOut)
@@ -54,7 +54,7 @@ struct SongListCellView: View {
                                     .foregroundColor(.grayScale1)
                             }
                         })
-                        .disabled(songEditButtonTap)
+                        .disabled(songEditButtonTapped)
                 }
             }
             .padding(.horizontal, 20)

--- a/Semo/Views/AllSongList/SongListCellView.swift
+++ b/Semo/Views/AllSongList/SongListCellView.swift
@@ -30,9 +30,11 @@ struct SongListCellView: View {
                         Text(song.title ?? "제목 없음")
                             .font(.system(size: 20, weight: .semibold))
                             .foregroundColor(.grayScale1)
+                            .multilineTextAlignment(.leading)
                         Text(song.singer ?? "가수 없음")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundColor(.grayScale2)
+                            .multilineTextAlignment(.leading)
                     }
                     .transition(.slide)
                     .animation(.easeInOut)

--- a/Semo/Views/AllSongList/SongListView.swift
+++ b/Semo/Views/AllSongList/SongListView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SongListView: View {
     @Binding var songList: [Song]
     @Binding var refreshView: Bool
-    @Binding var songEditButtonTap: Bool
+    @Binding var songEditButtonTapped: Bool
     
     // MARK: - BODY
     var body: some View {
@@ -24,7 +24,7 @@ struct SongListView: View {
                     .fontWeight(.medium)
                 Spacer()
                 SongEditButtonView(buttonName: "목록 편집", buttonWidth: 80) {
-                    self.songEditButtonTap.toggle()
+                    self.songEditButtonTapped.toggle()
                 }
             }
             // FIXME: - trailing을 추가하지 않으면 목록 편집 버튼이 오른쪽으로 치우침
@@ -35,7 +35,7 @@ struct SongListView: View {
                     .background(Color.grayScale6)
                     .frame(width: 350)                
                 ForEach(songList) {
-                    SongListCellView(songEditButtonTap: $songEditButtonTap, refreshView: $refreshView, song: $0)
+                    SongListCellView(songEditButtonTapped: $songEditButtonTapped, refreshView: $refreshView, song: $0)
                     Divider()
                         .background(Color.grayScale6)
                         .frame(width: 350)
@@ -45,7 +45,7 @@ struct SongListView: View {
             }
         }
         .padding(.top, 80)
-        .onChange(of: songEditButtonTap, perform: { _ in
+        .onChange(of: songEditButtonTapped, perform: { _ in
             songList = CoreDataManager.shared.fetchSongList() ?? []
             print("노래 편집")
         })
@@ -58,7 +58,7 @@ struct SongListView: View {
             self.songList = CoreDataManager.shared.fetchSongList() ?? []
         }
         .onDisappear {
-            self.songEditButtonTap = false
+            self.songEditButtonTapped = false
         }
     }
 }

--- a/Semo/Views/MainView.swift
+++ b/Semo/Views/MainView.swift
@@ -11,6 +11,7 @@ struct MainView: View {
     @State var currentTab: Int = 0
     @State var songEditButtonTapped: Bool = false
     @State var listEditButtonTapped: Bool = false
+    @State var listDetailEditButtonTapped: Bool = false
     @State var mainFetch: Bool = false
     @State var isPopToRoot: Bool = false
     @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
@@ -30,7 +31,7 @@ struct MainView: View {
                 // -------------------------------------------
                 
                 TabView(selection: self.$currentTab) {
-                    SongListView(songList: $songList, refreshView: $mainFetch, songEditButtonTap: $songEditButtonTapped).tag(0)
+                    SongListView(songList: $songList, refreshView: $mainFetch, songEditButtonTapped: $songEditButtonTapped).tag(0)
                     SingingListView(songList: $songList, songEditButtonTapped: $songEditButtonTapped, listEditButtonTapped: $listEditButtonTapped).tag(1)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))

--- a/Semo/Views/SingingList/DeleteSingingListButtonView.swift
+++ b/Semo/Views/SingingList/DeleteSingingListButtonView.swift
@@ -26,14 +26,8 @@ struct DeleteSingingListButtonView: View {
             Button("삭제", role: .destructive) {
                 // TODO: - 리스트 삭제 코드
                 CoreDataManager.shared.deleteSingingList(singingList: singingList)
-                listEditButtonTapped = false
+                self.listEditButtonTapped = false
             }
         }
     }
 }
-
-//struct DeleteSingingListButtonView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        DeleteSingingListButtonView()
-//    }
-//}

--- a/Semo/Views/SingingList/SingingListCellView.swift
+++ b/Semo/Views/SingingList/SingingListCellView.swift
@@ -32,9 +32,11 @@ struct SingingListCellView: View {
                         Text(singingList.title ?? "제목없음")
                             .font(.system(size: 20, weight: .semibold))
                             .foregroundColor(.grayScale1)
+                            .multilineTextAlignment(.leading)
                         Text("총 \(singingList.count)곡")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundColor(.grayScale2)
+                            .multilineTextAlignment(.leading)
                     }
                     .transition(.slide)
                     .animation(.easeInOut)

--- a/Semo/Views/SingingList/SingingListCellView.swift
+++ b/Semo/Views/SingingList/SingingListCellView.swift
@@ -26,7 +26,7 @@ struct SingingListCellView: View {
                     // TODO: - animation(_:value:)로 변경
                         .animation(.easeInOut)
                 }
-                NavigationLink(destination: SingingListDetailView(songList: $songList, listEditButtonTapped: $listEditButtonTapped, songEditButtonTapped: $songEditButtonTapped, singingList: singingList, singingListTitle: singingList.title ?? "제목없음")) {
+                NavigationLink(destination: SingingListDetailView(songList: $songList, listDetailEditButtonTapped: $listEditButtonTapped, singingList: singingList, singingListTitle: singingList.title ?? "제목없음")) {
                     // MARK: - 노래 정보 표시
                     VStack(alignment: .leading, spacing: 10) {
                         Text(singingList.title ?? "제목없음")

--- a/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
+++ b/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct DeleteFromSongToSingingListView: View {
+    @Environment(\.managedObjectContext) private var viewContext
     @Binding var songEditButtonTapped: Bool
     
     var song: Song
@@ -15,7 +16,12 @@ struct DeleteFromSongToSingingListView: View {
     
     var body: some View {
         Button {
-            song.removeFromSongToSingingList(singingList)            
+            song.removeFromSongToSingingList(singingList)
+            do {
+                try viewContext.save()
+            } catch {
+                print(error.localizedDescription)
+            }
             self.songEditButtonTapped = false
             print("노래 리스트에서 삭제")
         } label: {

--- a/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
+++ b/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
@@ -18,6 +18,7 @@ struct DeleteFromSongToSingingListView: View {
     var body: some View {
         Button {
             song.removeFromSongToSingingList(singingList)
+            self.songEditButtonTapped = false
 //            self.showDeleteAlert = true
             print("노래 리스트에서 삭제")
         } label: {

--- a/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
+++ b/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct DeleteFromSongToSingingListView: View {
-//    @State var showDeleteAlert: Bool = false
-    @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
     @Binding var songEditButtonTapped: Bool
     
     var song: Song
@@ -17,20 +15,12 @@ struct DeleteFromSongToSingingListView: View {
     
     var body: some View {
         Button {
-            song.removeFromSongToSingingList(singingList)
+            song.removeFromSongToSingingList(singingList)            
             self.songEditButtonTapped = false
-//            self.showDeleteAlert = true
             print("노래 리스트에서 삭제")
         } label: {
             Image(systemName: "minus.circle.fill")
                 .foregroundColor(.grayScale3)
         }
-//        .alert("이 노래를 리스트에서 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
-//            Button("취소", role: .cancel) {}
-//            Button("삭제", role: .destructive) {
-//                song.removeFromSongToSingingList(singingList)
-//                self.songEditButtonTapped = false
-//            }
-//        }
     }
 }

--- a/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
+++ b/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
@@ -1,0 +1,35 @@
+//
+//  DeleteFromSongToSingingListView.swift
+//  Semo
+//
+//  Created by 유정인 on 2022/10/05.
+//
+
+import SwiftUI
+
+struct DeleteFromSongToSingingListView: View {
+//    @State var showDeleteAlert: Bool = false
+    @State var songList: [Song] = CoreDataManager.shared.fetchSongList() ?? []
+    @Binding var songEditButtonTapped: Bool
+    
+    var song: Song
+    var singingList: SingingList
+    
+    var body: some View {
+        Button {
+            song.removeFromSongToSingingList(singingList)
+//            self.showDeleteAlert = true
+            print("노래 리스트에서 삭제")
+        } label: {
+            Image(systemName: "minus.circle.fill")
+                .foregroundColor(.grayScale3)
+        }
+//        .alert("이 노래를 리스트에서 삭제하시겠습니까?", isPresented: $showDeleteAlert) {
+//            Button("취소", role: .cancel) {}
+//            Button("삭제", role: .destructive) {
+//                song.removeFromSongToSingingList(singingList)
+//                self.songEditButtonTapped = false
+//            }
+//        }
+    }
+}

--- a/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
@@ -39,6 +39,7 @@ struct SingingListDetailCellView: View {
                     .animation(.easeInOut)
                     Spacer()
                     // MARK: - Tune 정보 표시
+                    // TODO: - 키 정보 나타내는 캡슐 모듈화
                     Capsule()
                         .frame(width: 72, height: 32)
                         .foregroundColor(.grayScale7)

--- a/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
@@ -9,41 +9,56 @@ import SwiftUI
 
 struct SingingListDetailCellView: View {
     @Binding var singingListViewFetch: Bool
-    @Binding var songEditButtonTap: Bool
+    @Binding var listDetailEditButtonTapped: Bool
     
     var singingList: SingingList
+    var song: Song
     
     // MARK: - BODY
     var body: some View {
-        VStack {
-            // MARK: - 전체 노래 리스트 상단 바
+        Button {
+        } label: {
             HStack {
-                // TODO: - 데이터 크기로 값 받아오기
-                Text("노래 목록 (\(singingList.count))")
-                    .font(.subheadline)
-                    .foregroundColor(.grayScale2)
-                    .fontWeight(.medium)                
-                Spacer()
-            }
-            .padding(EdgeInsets(top: 15, leading: 20, bottom: 15, trailing: 0))
-            // MARK: - 노래 리스트 생성 및 스크롤 추가
-            ScrollView {
-                Divider()
-                    .background(Color.grayScale6)
-                    .frame(width: 350)                
-                ForEach(singingList.songArray) {
-                    SongListCellView(songEditButtonTap: $songEditButtonTap, refreshView: $singingListViewFetch, song: $0)
-                    Divider()
-                        .background(Color.grayScale6)
-                        .frame(width: 350)
+                if listDetailEditButtonTapped == true {
+                    DeleteFromSongToSingingListView(songEditButtonTapped: $listDetailEditButtonTapped, song: song, singingList: singingList)
+                        .padding(.trailing, 8)
+                        .transition(.move(edge: .leading))
+                        .animation(.easeInOut)
                 }
-                .padding(.top, 10)
-                // TODO: - 이후 업데이트에서 새 노래 추가가 아닌 기존 노래 추가로 기능 변경
-//                AddSongButtonView()
-                Spacer()
-
+                NavigationLink(destination: SongDetailView(song: song, genderIndex: song.gender ?? "남키", levelPickerIndex: ["하", "중", "상"].firstIndex(of: song.level ?? "중") ?? 1, tunePickerIndex: ["-6", "-5", "-4", "-3", "-2", "-1", "+0", "+1", "+2", "+3", "+4", "+5", "+6"].firstIndex(of: song.tune ?? "+0") ?? 6)) {
+                    // MARK: - 노래 정보 표시
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(song.title ?? "제목 없음")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundColor(.grayScale1)
+                        Text(song.singer ?? "가수 없음")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundColor(.grayScale2)
+                    }
+                    .transition(.slide)
+                    .animation(.easeInOut)
+                    Spacer()
+                    // MARK: - Tune 정보 표시
+                    Capsule()
+                        .frame(width: 72, height: 32)
+                        .foregroundColor(.grayScale7)
+                        .overlay(content: {
+                            switch song.gender {
+                            case "여키" :
+                                Text("\(Text("여키").foregroundColor(.womanColor)) \(song.tune ?? "+0")")
+                                    .foregroundColor(.grayScale1)
+                            case "혼성" :
+                                Text("\(Text("혼성").foregroundColor(.duetColor)) \(song.tune ?? "+0")")
+                                    .foregroundColor(.grayScale1)
+                            default :
+                                Text("\(Text("남키").foregroundColor(.manColor)) \(song.tune ?? "+0")")
+                                    .foregroundColor(.grayScale1)
+                            }
+                        })
+                        .disabled(listDetailEditButtonTapped)
+                }
             }
+            .padding(.horizontal, 20)
         }
-        .padding(.top, 110)
     }
 }

--- a/Semo/Views/SingingListDetail/SingingListDetailView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailView.swift
@@ -75,13 +75,15 @@ struct SingingListDetailView: View {
                         // TODO: - 이후 업데이트에서 새 노래 추가가 아닌 기존 노래 추가로 기능 변경
         //                AddSongButtonView()
                         Spacer()
-
                     }
                 }
                 .padding(.top, 175)
             }
             .ignoresSafeArea(.all)
         }
+        .onChange(of: $listDetailEditButtonTapped, perform: {
+            
+        })
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 SongEditButtonView(buttonName: listDetailEditButtonTapped == true ? "완료" : "편집", buttonWidth: 50) {

--- a/Semo/Views/SingingListDetail/SingingListDetailView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailView.swift
@@ -15,8 +15,7 @@ struct SingingListDetailView: View {
     @State var singingListViewFetch: Bool = false
     @State var changedSingingListTitle: String = ""
     @Binding var songList: [Song]
-    @Binding var listEditButtonTapped: Bool
-    @Binding var songEditButtonTapped: Bool
+    @Binding var listDetailEditButtonTapped: Bool
     
     var singingList: SingingList
     
@@ -35,8 +34,8 @@ struct SingingListDetailView: View {
                 Rectangle()
                     .edgesIgnoringSafeArea(.all)
                     .frame(height: UIScreen.main.bounds.height * 0.16)
-                    .foregroundColor(songEditButtonTapped == true ? .grayScale7 : .grayScale6)
-                    .opacity(songEditButtonTapped == true ? 1 : 0.4)
+                    .foregroundColor(listDetailEditButtonTapped == true ? .grayScale7 : .grayScale6)
+                    .opacity(listDetailEditButtonTapped == true ? 1 : 0.4)
                     .padding(.bottom, 650)
                 TextField("", text: $singingListTitle, onEditingChanged: { changed in
                     self.isSingingListTitleEditing = changed
@@ -48,18 +47,45 @@ struct SingingListDetailView: View {
                         .font(.system(size: 28, weight: .semibold))
                         .foregroundColor(.grayScale2)
                 }
-                .disabled(!songEditButtonTapped)
-                .underlineTextField(isEditing: isSingingListTitleEditing, isFull: !singingListTitle.isEmpty, inset: 55, active: songEditButtonTapped)
+                .disabled(!listDetailEditButtonTapped)
+                .underlineTextField(isEditing: isSingingListTitleEditing, isFull: !singingListTitle.isEmpty, inset: 55, active: listDetailEditButtonTapped)
                 .padding(EdgeInsets(top: 0, leading: 10, bottom: 600, trailing: 10))
-                SingingListDetailCellView(singingListViewFetch: $singingListViewFetch, songEditButtonTap: $songEditButtonTapped, singingList: singingList)
-                    .padding(.top, 60)
+                VStack {
+                    // MARK: - 전체 노래 리스트 상단 바
+                    HStack {
+                        Text("노래 목록 (\(singingList.count))")
+                            .font(.subheadline)
+                            .foregroundColor(.grayScale2)
+                            .fontWeight(.medium)
+                        Spacer()
+                    }
+                    .padding(EdgeInsets(top: 15, leading: 20, bottom: 15, trailing: 0))
+                    // MARK: - 노래 리스트 생성 및 스크롤 추가
+                    ScrollView {
+                        Divider()
+                            .background(Color.grayScale6)
+                            .frame(width: 350)
+                        ForEach(singingList.songArray) {
+                            SingingListDetailCellView(singingListViewFetch: $singingListViewFetch, listDetailEditButtonTapped: $listDetailEditButtonTapped, singingList: singingList, song: $0)
+                            Divider()
+                                .background(Color.grayScale6)
+                                .frame(width: 350)
+                        }
+                        .padding(.top, 10)
+                        // TODO: - 이후 업데이트에서 새 노래 추가가 아닌 기존 노래 추가로 기능 변경
+        //                AddSongButtonView()
+                        Spacer()
+
+                    }
+                }
+                .padding(.top, 175)
             }
             .ignoresSafeArea(.all)
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                SongEditButtonView(buttonName: songEditButtonTapped == true ? "완료" : "편집", buttonWidth: 50) {
-                    self.songEditButtonTapped.toggle()
+                SongEditButtonView(buttonName: listDetailEditButtonTapped == true ? "완료" : "편집", buttonWidth: 50) {
+                    self.listDetailEditButtonTapped.toggle()
                     CoreDataManager.shared.updateSingingListTitle(title: singingListTitle, singingList: singingList)
                 }
                 .padding(.trailing, 20)
@@ -67,7 +93,7 @@ struct SingingListDetailView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                if songEditButtonTapped == false {
+                if listDetailEditButtonTapped == false {
                     CustomBackButton(buttonName: "") {
                         self.presentationMode.wrappedValue.dismiss()
                     }
@@ -75,7 +101,7 @@ struct SingingListDetailView: View {
                 } else {
                     Button {
                         // TODO: - 뷰 리프레시 필요
-                        self.songEditButtonTapped.toggle()
+                        self.listDetailEditButtonTapped.toggle()
                         print("리스트 편집 그만하기")
                     } label: {
                         Image(systemName: "xmark")
@@ -93,7 +119,7 @@ struct SingingListDetailView: View {
             }
         })
         .onDisappear {
-            self.songEditButtonTapped = false
+            self.listDetailEditButtonTapped = false
         }
         .onChange(of: singingListViewFetch, perform: { _ in
             songList = CoreDataManager.shared.fetchSongList() ?? []

--- a/Semo/Views/SingingListDetail/SingingListDetailView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailView.swift
@@ -81,9 +81,6 @@ struct SingingListDetailView: View {
             }
             .ignoresSafeArea(.all)
         }
-        .onChange(of: $listDetailEditButtonTapped, perform: {
-            
-        })
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 SongEditButtonView(buttonName: listDetailEditButtonTapped == true ? "완료" : "편집", buttonWidth: 50) {

--- a/Semo/Views/SongDetail/SongInfoView.swift
+++ b/Semo/Views/SongDetail/SongInfoView.swift
@@ -17,10 +17,12 @@ struct SongInfoView: View {
             Text(song.title ?? "제목 없음")
                 .font(.system(size: 24, weight: .semibold))
                 .foregroundColor(.white)
+                .multilineTextAlignment(.center)
             Text(song.singer ?? "가수 없음")
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(.grayScale2)
                 .padding(EdgeInsets(top: 2, leading: 0, bottom: 0, trailing: 0))
+                .multilineTextAlignment(.center)
         }
     }
 }


### PR DESCRIPTION
## 작업사항
![Simulator Screen Recording - iPhone 14 - 2022-10-05 at 15 46 28](https://user-images.githubusercontent.com/93065107/193997793-0973430d-df5f-4f2c-90e4-067721ff058b.gif)

- 리스트 내 노래 리스트 뷰 분리
- 리스트에서만 노래 삭제하는 기능 추가
- 노래 제목, 가수 텍스트 좌측 정렬
- 싱잉리스트 타이틀, 곡의 총 개수 좌측 정렬
- 노래 상세페이지 가수랑 곡 가운데 정렬
<!--- 작업 사항들의 간단한 설명들을 작성해주세요. -->

## 이슈 번호
#89 
<!-- 이슈 번호를 연결해주세요. -->


## 특이사항 (optional)
- 노래를 리스트에 추가하거나 삭제할 때마다 메인뷰의 노래 순서가 바뀜
<!--- 특이 사항이 있으시면 작성해주세요. -->
