### PR TITLE
[2022.10.06] hotfix/SongDetailViewSaveButton >> 저장버튼 활성화 조건 수정

### DIFF
--- a/Semo/Views/SongDetail/SongDetailView.swift
+++ b/Semo/Views/SongDetail/SongDetailView.swift
@@ -80,10 +80,6 @@ struct SongDetailView: View {
                             isPresented.toggle()
                         }
                         .padding(EdgeInsets(top: 16, leading: 0, bottom: 0, trailing: 34))
-                        .onChange(of: song.singingListArray, perform: { _ in
-                            isChanged = true
-                            print("changed")
-                        })
                     }
                     
                     ForEach(song.singingListArray) {


### PR DESCRIPTION
## 작업사항
- SongDetailView에서 싱잉리스트를 수정했을 때는 저장 버튼 활성화되지 않도록 수정했습니다.
<!--- 작업 사항들의 간단한 설명들을 작성해주세요. -->

## 이슈 번호
#117
<!-- 이슈 번호를 연결해주세요. -->


## 특이사항 (optional)
- 싱잉리스트는 수정하면 코어데이터에 바로 반영됩니다.
<!--- 특이 사항이 있으시면 작성해주세요. -->
