### PR TITLE
[fix] #122 리스트 디테일 뷰에서 보이는 노래의 제목과 가수 왼쪽 정렬

### DIFF
--- a/Semo/Views/AllSongList/SongListCellView.swift
+++ b/Semo/Views/AllSongList/SongListCellView.swift
@@ -30,12 +30,11 @@ struct SongListCellView: View {
                         Text(song.title ?? "제목 없음")
                             .font(.system(size: 20, weight: .semibold))
                             .foregroundColor(.grayScale1)
-                            .multilineTextAlignment(.leading)
                         Text(song.singer ?? "가수 없음")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundColor(.grayScale2)
-                            .multilineTextAlignment(.leading)
                     }
+                    .multilineTextAlignment(.leading)
                     .transition(.slide)
                     .animation(.easeInOut)
                     Spacer()

--- a/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
@@ -37,6 +37,7 @@ struct SingingListDetailCellView: View {
                             .foregroundColor(.grayScale2)
                             .multilineTextAlignment(.leading)
                     }
+                    .multilineTextAlignment(.leading)
                     .transition(.slide)
                     .animation(.easeInOut)
                     Spacer()

--- a/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
@@ -31,9 +31,11 @@ struct SingingListDetailCellView: View {
                         Text(song.title ?? "제목 없음")
                             .font(.system(size: 20, weight: .semibold))
                             .foregroundColor(.grayScale1)
+                            .multilineTextAlignment(.leading)
                         Text(song.singer ?? "가수 없음")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundColor(.grayScale2)
+                            .multilineTextAlignment(.leading)
                     }
                     .transition(.slide)
                     .animation(.easeInOut)

--- a/Semo/Views/SongDetail/SongInfoView.swift
+++ b/Semo/Views/SongDetail/SongInfoView.swift
@@ -17,13 +17,12 @@ struct SongInfoView: View {
             Text(song.title ?? "제목 없음")
                 .font(.system(size: 24, weight: .semibold))
                 .foregroundColor(.white)
-                .multilineTextAlignment(.center)
             Text(song.singer ?? "가수 없음")
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(.grayScale2)
                 .padding(EdgeInsets(top: 2, leading: 0, bottom: 0, trailing: 0))
-                .multilineTextAlignment(.center)
         }
+        .multilineTextAlignment(.center)
     }
 }
 


### PR DESCRIPTION
## 작업사항
- 리스트 디테일 뷰에서 노래 제목과 가수 왼쪽 정렬로 변경
<!--- 작업 사항들의 간단한 설명들을 작성해주세요. -->

## 이슈 번호
#122
<!-- 이슈 번호를 연결해주세요. -->

<!--- 특이 사항이 있으시면 작성해주세요. -->
