### PR TITLE
[2022.10.16] feat/singingListDeleteSong >>> 싱잉리스트 X버튼 UI를 삭제했습니다

### DIFF
--- a/Semo/Views/SingingListDetail/AddSongButtonView.swift
+++ b/Semo/Views/SingingListDetail/AddSongButtonView.swift
@@ -32,9 +32,3 @@ struct AddSongButtonView: View {
         .padding(EdgeInsets(top: 15, leading: 20, bottom: 120, trailing: 0))
     }
 }
-
-//struct AddSongButtonView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        AddSongButtonView()
-//    }
-//}

--- a/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
+++ b/Semo/Views/SingingListDetail/DeleteFromSongToSingingListView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct DeleteFromSongToSingingListView: View {
     @Environment(\.managedObjectContext) private var viewContext
-    @Binding var songEditButtonTapped: Bool
+    @Binding var listDetailEditButtonTapped: Bool
     
     var song: Song
     var singingList: SingingList
@@ -22,7 +22,7 @@ struct DeleteFromSongToSingingListView: View {
             } catch {
                 print(error.localizedDescription)
             }
-            self.songEditButtonTapped = false
+            self.listDetailEditButtonTapped = false
             print("노래 리스트에서 삭제")
         } label: {
             Image(systemName: "minus.circle.fill")

--- a/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailCellView.swift
@@ -20,7 +20,7 @@ struct SingingListDetailCellView: View {
         } label: {
             HStack {
                 if listDetailEditButtonTapped == true {
-                    DeleteFromSongToSingingListView(songEditButtonTapped: $listDetailEditButtonTapped, song: song, singingList: singingList)
+                    DeleteFromSongToSingingListView(listDetailEditButtonTapped: $listDetailEditButtonTapped, song: song, singingList: singingList)
                         .padding(.trailing, 8)
                         .transition(.move(edge: .leading))
                         .animation(.easeInOut)

--- a/Semo/Views/SingingListDetail/SingingListDetailView.swift
+++ b/Semo/Views/SingingListDetail/SingingListDetailView.swift
@@ -103,9 +103,9 @@ struct SingingListDetailView: View {
                         self.listDetailEditButtonTapped.toggle()
                         print("리스트 편집 그만하기")
                     } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundColor(.white)
+//                        Image(systemName: "xmark")
+//                            .font(.system(size: 16, weight: .medium))
+//                            .foregroundColor(.white)
                     }
                     .navigationBarBackButtonHidden(true)
                 }


### PR DESCRIPTION
## 작업사항
![Simulator Screen Recording - iPhone 14 - 2022-10-16 at 23 18 08](https://user-images.githubusercontent.com/93065107/196040520-49131fc9-facc-43c9-bae2-05ca760fbad2.gif)

기존에 리스트 편집 중에 X버튼을 누르면 수정사항들이 반영되지 않는 기능을 뺐습니다

<!--- 작업 사항들의 간단한 설명들을 작성해주세요. -->

## 이슈 번호
#89
<!-- 이슈 번호를 연결해주세요. -->




<!--- 특이 사항이 있으시면 작성해주세요. -->
